### PR TITLE
Validation using QCSubmit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# IDEs
+.idea*

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -4,11 +4,15 @@ dependencies:
     # Base depends
   - python
   - pip
+  - openforcefield
+  - cmiles
+  - numpy
 
     # Testing
   - pytest
   - pytest-cov
   - codecov
+  - qcportal
 
     # Pip-only installs
   #- pip:

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -1,10 +1,16 @@
 name: test
+
 channels:
+  - conda-forge
+  - omnia
+  - openeye
+
 dependencies:
     # Base depends
   - python
   - pip
   - openforcefield
+  - openeye-toolkits
   - cmiles
   - numpy
 

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -13,6 +13,8 @@ dependencies:
   - openeye-toolkits
   - cmiles
   - numpy
+  - pandas
+  - mdtraj
 
     # Testing
   - pytest

--- a/devtools/travis-ci/before_install.sh
+++ b/devtools/travis-ci/before_install.sh
@@ -15,8 +15,8 @@ else
     MINICONDA=Miniconda3-latest-Linux-x86_64.sh
 fi
 MINICONDA_HOME=$HOME/miniconda
-MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
-wget -q https://repo.continuum.io/miniconda/$MINICONDA
+MINICONDA_MD5=$(wget -qO- https://repo.anaconda.com/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
+wget -q https://repo.anaconda.com/miniconda/$MINICONDA
 if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
     echo "Miniconda MD5 mismatch"
     exit 1

--- a/devtools/travis-ci/before_install.sh
+++ b/devtools/travis-ci/before_install.sh
@@ -31,6 +31,7 @@ echo "conda activate" >> ~/.bashrc  # Activate conda
 source ~/.bashrc  # source file to get new commands
 #export PATH=$MINICONDA_HOME/bin:$PATH  # Old way, should not be needed anymore
     
+conda config --add channels omnia 
 conda config --add channels conda-forge
     
 conda config --set always_yes yes

--- a/devtools/travis-ci/before_install.sh
+++ b/devtools/travis-ci/before_install.sh
@@ -31,7 +31,6 @@ echo "conda activate" >> ~/.bashrc  # Activate conda
 source ~/.bashrc  # source file to get new commands
 #export PATH=$MINICONDA_HOME/bin:$PATH  # Old way, should not be needed anymore
     
-conda config --add channels omnia 
 conda config --add channels conda-forge
     
 conda config --set always_yes yes

--- a/openbenchmark/tests/test_valiation.py
+++ b/openbenchmark/tests/test_valiation.py
@@ -1,41 +1,16 @@
 import pytest
-
 import qcportal as ptl
-from openforcefield.utils.toolkits import UndefinedStereochemistryError
 
-from openbenchmark.validation import QCValidator, run_through_openeye, sanity_check_bond_order
-
-
-client = ptl.FractalClient()
-
-ds = client.get_collection('OptimizationDataset', 'OpenFF Full Optimization Benchmark 1')
-
-good_smiles_in = 'CC(C)O-0'
-bad_smiles_in = 'CO/N=C/1\C[N@](C[C@H]1C[NH3+])c2c(cc3c(=O)c(cn(c3n2)C4CC4)C(=O)[O-])F-3'
+from openbenchmark.validation import QCValidator
 
 
-def test_run_through_openeye():
-    run_through_openeye(ds.get_record(good_smiles_in, specification='default'))
+class TestValidator:
 
-    with pytest.raises(UndefinedStereochemistryError):
-        run_through_openeye(ds.get_record(bad_smiles_in, specification='default'))
+    @pytest.fixture
+    def dataset(self):
+        client = ptl.FractalClient()
+        dataset = client.get_collection('OptimizationDataset', 'OpenFF Full Optimization Benchmark 1')
+        return dataset
 
-
-def test_bond_santity_checker():
-    sanity_check_bond_order(good_smiles_in, ds=ds)
-
-    with pytest.raises(AssertionError):
-        sanity_check_bond_order(bad_smiles_in, ds=ds)
-
-
-def test_validator_basic():
-    qcv = QCValidator(
-        ds,
-        check_intra_h_bonds=False,
-        check_proton_transfer=True,
-        check_stereochemical_changes=True,
-        check_bond_order_changes=True
-    )
-    
-    qcv.run_validation()
-    qcv.to_pandas().head()
+    def test_validator(self, dataset):
+        QCValidator(dataset=dataset)

--- a/openbenchmark/tests/test_valiation.py
+++ b/openbenchmark/tests/test_valiation.py
@@ -3,20 +3,26 @@ import pytest
 import qcportal as ptl
 from openforcefield.utils.toolkits import UndefinedStereochemistryError
 
-from openbenchmark.validation import run_through_openeye
+from openbenchmark.validation import run_through_openeye, sanity_check_bond_order
 
 
 client = ptl.FractalClient()
 
 ds = client.get_collection('OptimizationDataset', 'OpenFF Full Optimization Benchmark 1')
 
+good_smiles_in = 'CC(C)O-0'
+bad_smiles_in = 'CO/N=C/1\C[N@](C[C@H]1C[NH3+])c2c(cc3c(=O)c(cn(c3n2)C4CC4)C(=O)[O-])F-3'
 
-def test_run_through_openeye_good():
-    good_smiles_in = 'CC(C)O-0'
+
+def test_run_through_openeye():
     run_through_openeye(ds.get_record(good_smiles_in, specification='default'))
 
-def test_run_through_openeye_bad():
-    # TODO: Split this out into various tests capturing specific
-    bad_smiles_in = 'CO/N=C/1\C[N@](C[C@H]1C[NH3+])c2c(cc3c(=O)c(cn(c3n2)C4CC4)C(=O)[O-])F-3'
     with pytest.raises(UndefinedStereochemistryError):
         run_through_openeye(ds.get_record(bad_smiles_in, specification='default'))
+
+
+def test_bond_santity_checker():
+    sanity_check_bond_order(good_smiles_in, ds=ds)
+
+    with pytest.raises(AssertionError):
+        sanity_check_bond_order(bad_smiles_in, ds=ds)

--- a/openbenchmark/tests/test_valiation.py
+++ b/openbenchmark/tests/test_valiation.py
@@ -28,15 +28,14 @@ def test_bond_santity_checker():
         sanity_check_bond_order(bad_smiles_in, ds=ds)
 
 
-ds = client.get_collection('OptimizationDataset', 'OpenFF Optimization Set 1')
-
-qcv = QCValidator(
-    small_ds,
-    check_intra_h_bonds=False,
-    check_proton_transfer=True,
-    check_stereochemical_changes=True,
-    check_bond_order_changes=True
-)
-
-qcv.run_validation()
-qcv.to_pandas().head()
+def test_validator_basic():
+    qcv = QCValidator(
+        ds,
+        check_intra_h_bonds=False,
+        check_proton_transfer=True,
+        check_stereochemical_changes=True,
+        check_bond_order_changes=True
+    )
+    
+    qcv.run_validation()
+    qcv.to_pandas().head()

--- a/openbenchmark/tests/test_valiation.py
+++ b/openbenchmark/tests/test_valiation.py
@@ -3,7 +3,7 @@ import pytest
 import qcportal as ptl
 from openforcefield.utils.toolkits import UndefinedStereochemistryError
 
-from openbenchmark.validation import run_through_openeye, sanity_check_bond_order
+from openbenchmark.validation import QCValidator, run_through_openeye, sanity_check_bond_order
 
 
 client = ptl.FractalClient()
@@ -26,3 +26,17 @@ def test_bond_santity_checker():
 
     with pytest.raises(AssertionError):
         sanity_check_bond_order(bad_smiles_in, ds=ds)
+
+
+ds = client.get_collection('OptimizationDataset', 'OpenFF Optimization Set 1')
+
+qcv = QCValidator(
+    small_ds,
+    check_intra_h_bonds=False,
+    check_proton_transfer=True,
+    check_stereochemical_changes=True,
+    check_bond_order_changes=True
+)
+
+qcv.run_validation()
+qcv.to_pandas().head()

--- a/openbenchmark/tests/test_valiation.py
+++ b/openbenchmark/tests/test_valiation.py
@@ -1,0 +1,22 @@
+import pytest
+
+import qcportal as ptl
+from openforcefield.utils.toolkits import UndefinedStereochemistryError
+
+from openbenchmark.validation import run_through_openeye
+
+
+client = ptl.FractalClient()
+
+ds = client.get_collection('OptimizationDataset', 'OpenFF Full Optimization Benchmark 1')
+
+
+def test_run_through_openeye_good():
+    good_smiles_in = 'CC(C)O-0'
+    run_through_openeye(ds.get_record(good_smiles_in, specification='default'))
+
+def test_run_through_openeye_bad():
+    # TODO: Split this out into various tests capturing specific
+    bad_smiles_in = 'CO/N=C/1\C[N@](C[C@H]1C[NH3+])c2c(cc3c(=O)c(cn(c3n2)C4CC4)C(=O)[O-])F-3'
+    with pytest.raises(UndefinedStereochemistryError):
+        run_through_openeye(ds.get_record(bad_smiles_in, specification='default'))

--- a/openbenchmark/validation.py
+++ b/openbenchmark/validation.py
@@ -1,0 +1,26 @@
+import numpy as np
+import openeye as oechem
+from openforcefield.topology.molecule import Molecule
+from cmiles.utils import _symbols, BOHR_2_ANGSTROM, ANGSROM_2_BOHR
+
+
+def run_through_openeye(record):
+    coords = record.get_final_molecule().dict()['geometry']
+    geometry = np.asarray(coords, dtype=float)*BOHR_2_ANGSTROM
+    symbols = record.get_final_molecule().dict()['symbols']
+
+    oemol = oechem.OEMol()
+
+    for s in symbols:
+        oemol.NewAtom(_symbols[s])
+
+    oemol.SetCoords(oechem.OEFloatArray(geometry.reshape(-1)))
+    oemol.SetDimension(3)
+
+    # Let OpenEye try to determine connectivity instead of trusting the connectivity in the record
+    oechem.OEDetermineConnectivity(oemol)
+    oechem.OEFindRingAtomsAndBonds(oemol)
+    oechem.OEPerceiveBondOrders(oemol)
+    oechem.OEAssignImplicitHydrogens(oemol)
+    oechem.OEAssignFormalCharges(oemol)
+    Molecule.from_openeye(oemol).to_rdkit()

--- a/openbenchmark/validation.py
+++ b/openbenchmark/validation.py
@@ -24,3 +24,36 @@ def run_through_openeye(record):
     oechem.OEAssignImplicitHydrogens(oemol)
     oechem.OEAssignFormalCharges(oemol)
     Molecule.from_openeye(oemol).to_rdkit()
+
+
+def sanity_check_bond_order(val, ds=None):
+    # TODO: get the smiles/cmiles in from the 'extras' in the record
+    entry = ds.get_entry(val)
+    smiles_in = entry.dict()['attributes']['canonical_isomeric_explicit_hydrogen_smiles']
+    mol_in = Molecule.from_smiles(smiles_in)
+    mol_in.assign_fractional_bond_orders(bond_order_model='am1-wiberg')
+    expected_bond_orders = [b.bond_order for b in mol_in.bonds]
+
+    record = ds.get_record(val, specification='default')
+
+    coords = record.get_final_molecule().dict()['geometry']
+    geometry = np.asarray(coords, dtype=float)*BOHR_2_ANGSTROM
+    symbols = record.get_final_molecule().dict()['symbols']
+
+    oemol = oechem.OEMol()
+
+    for s in symbols:
+        oemol.NewAtom(_symbols[s])
+
+    oemol.SetCoords(oechem.OEFloatArray(geometry.reshape(-1)))
+    oemol.SetDimension(3)
+    oechem.OEDetermineConnectivity(oemol)
+    oechem.OEDetermineConnectivity(oemol)
+    oechem.OEFindRingAtomsAndBonds(oemol)
+    oechem.OEAssignImplicitHydrogens(oemol)
+    oechem.OEPerceiveBondOrders(oemol)
+
+    found_bond_orders = [b.GetOrder() for b in oemol.GetBonds()]
+
+    for x, y in zip(expected_bond_orders, found_bond_orders):
+        assert x == y

--- a/openbenchmark/validation.py
+++ b/openbenchmark/validation.py
@@ -1,7 +1,111 @@
+
 import numpy as np
 import openeye as oechem
 from openforcefield.topology.molecule import Molecule
+import cmiles
 from cmiles.utils import _symbols, BOHR_2_ANGSTROM, ANGSROM_2_BOHR
+import mdtraj as md
+import pandas as pd
+
+
+class QCValidator:
+    """
+    Run throughValidate that a QCArchive entry against its CMILES representation in entry
+    """
+    def __init__(
+        self, dataset=None,
+        check_intra_h_bonds=True,
+        check_proton_transfer=True,
+        check_stereochemical_changes=True,
+        check_bond_order_changes=True,
+    ):
+
+        self._ds = dataset
+        self._check_intra_h_bonds = check_intra_h_bonds
+        self._check_proton_transfer = check_proton_transfer
+        self._check_stereochemical_changes = check_stereochemical_changes
+        self._check_bond_order_changes = check_bond_order_changes
+
+
+    def run_validation(self):
+
+        master_validation_dict = dict()
+
+        if self._check_proton_transfer:
+            proton_transfer_validation = dict()
+            for key, val in self._ds.data.records.items():
+                try:
+                    check = self.check_proton_transfer(key=key)
+                    proton_transfer_validation.update({key: check})
+                except:
+                    pass
+            master_validation_dict.update({'has_proton_transfer': proton_transfer_validation})
+
+        if self._check_bond_order_changes:
+            bond_order_changes_validation = dict()
+            for key, val in self._ds.data.records.items():
+                try:
+                    check = self.check_bond_order_changes(key=key)
+                    bond_order_changes_validation.update({key: check})
+                except:
+                    pass
+            master_validation_dict.update({'has_bond_order_changes': bond_order_changes_validation})
+
+        if self._check_stereochemical_changes:
+            stereochemistry_validation = dict()
+            for key, val in self._ds.data.records.items():
+                try:
+                    check = self.check_stereochemical_changes(key=key)
+                    stereochemistry_validation.update({key: check})
+                except:
+                    pass
+            master_validation_dict.update({'has_stereochemical_changes': stereochemistry_validation})
+
+        if self._check_intra_h_bonds:
+            h_bond_validation = dict()
+            for key, val in self._ds.data.records.items():
+                if key[1] == 'c':
+                    continue
+                try:
+                    check = self.check_intra_h_bonds(key=key)
+                    h_bond_validation.update({key: check})
+                except:
+                    pass
+            master_validation_dict.update({'has_intra_h_bonds': h_bond_validation})
+
+        self._validation_data = master_validation_dict
+
+
+    def to_pandas(self):
+        return pd.DataFrame(self._validation_data)
+
+
+    def check_intra_h_bonds(self, key=None):
+        record = self._ds.get_record(key, specification='default')
+        qc_mol = record.get_final_molecule()
+        qcjson_mol = qc_mol.dict(encoding='json')
+        oemol = cmiles.utils.load_molecule(qcjson_mol)
+        mol = Molecule.from_openeye(oemol)
+        mol.to_file(f'{key}.mol2', file_format='mol2')
+        trj = md.load(f'{key}.mol2')
+        h_bonds = md.baker_hubbard(trj)
+        num_h_bonds = h_bonds.shape[0]
+        if num_h_bonds > 0:
+            return True
+        else:
+            return False
+
+
+    def check_stereochemical_changes(self, key=None):
+        return False
+
+
+    def check_proton_transfer(self, key=None):
+        return False
+
+
+    def check_bond_order_changes(self, key=None):
+        return False
 
 
 def run_through_openeye(record):
@@ -47,7 +151,6 @@ def sanity_check_bond_order(val, ds=None):
 
     oemol.SetCoords(oechem.OEFloatArray(geometry.reshape(-1)))
     oemol.SetDimension(3)
-    oechem.OEDetermineConnectivity(oemol)
     oechem.OEDetermineConnectivity(oemol)
     oechem.OEFindRingAtomsAndBonds(oemol)
     oechem.OEAssignImplicitHydrogens(oemol)

--- a/openbenchmark/validation.py
+++ b/openbenchmark/validation.py
@@ -1,19 +1,21 @@
-
 import numpy as np
-import openeye as oechem
-from openforcefield.topology.molecule import Molecule
-import cmiles
-from cmiles.utils import _symbols, BOHR_2_ANGSTROM, ANGSROM_2_BOHR # TODO: Cleaner handling of units
 import mdtraj as md
 import pandas as pd
+from openforcefield.topology.molecule import Molecule
+import openeye as oechem
+import cmiles
+from cmiles.utils import _symbols, BOHR_2_ANGSTROM
 
+
+#  TODO: Cleaner handling of units
 
 class QCValidator:
     """
     Run throughValidate that a QCArchive entry against its CMILES representation in entry
     """
     def __init__(
-        self, dataset=None,
+        self,
+        dataset=None,
         check_intra_h_bonds=True,
         check_proton_transfer=True,
         check_stereochemical_changes=True,
@@ -38,7 +40,7 @@ class QCValidator:
                 try:
                     check = self.check_proton_transfer(key=key)
                     proton_transfer_validation.update({key: check})
-                except:
+                except Exception as _:
                     pass
             master_validation_dict.update({'has_proton_transfer': proton_transfer_validation})
 
@@ -51,8 +53,7 @@ class QCValidator:
                     try:
                         check = self.check_bond_order_changes(key=key)
                         bond_order_changes_validation.update({key: check})
-                    except Exception as e:
-                        print(e)
+                    except Exception as _:
                         pass
             master_validation_dict.update({'has_bond_order_changes': bond_order_changes_validation})
 
@@ -62,7 +63,7 @@ class QCValidator:
                 try:
                     check = self.check_stereochemical_changes(key=key)
                     stereochemistry_validation.update({key: check})
-                except:
+                except Exception as _:
                     pass
             master_validation_dict.update({'has_stereochemical_changes': stereochemistry_validation})
 
@@ -74,16 +75,14 @@ class QCValidator:
                 try:
                     check = self.check_intra_h_bonds(key=key)
                     h_bond_validation.update({key: check})
-                except:
+                except Exception as _:
                     pass
             master_validation_dict.update({'has_intra_h_bonds': h_bond_validation})
 
         self._validation_data = master_validation_dict
 
-
     def to_pandas(self):
         return pd.DataFrame(self._validation_data)
-
 
     def check_intra_h_bonds(self, key=None):
         record = self._ds.get_record(key, specification='default')
@@ -100,14 +99,11 @@ class QCValidator:
         else:
             return False
 
-
     def check_stereochemical_changes(self, key=None):
         return False
 
-
     def check_proton_transfer(self, key=None):
         return False
-
 
     def check_bond_order_changes(self, key=None):
         # TODO: Replace this with a proper WBO-based inference
@@ -123,7 +119,7 @@ class QCValidator:
 
         oemol.SetCoords(oechem.OEFloatArray(geometry.reshape(-1)))
         oemol.SetDimension(3)
-    
+
         # Let OpenEye try to determine connectivity instead of trusting the connectivity in the record
         oechem.OEDetermineConnectivity(oemol)
         oechem.OEFindRingAtomsAndBonds(oemol)


### PR DESCRIPTION
## Description
Like #3 but starting to use things @jthorton already built up in https://github.com/openforcefield/qcsubmit (currently in PR https://github.com/openforcefield/qcsubmit/pull/2). Immediately, this uses the `OptimizationCollectionResult` to store the data, and then directly calls some functions (for now, `record.detect_connectivity_changes_wbo` and `record.detect_connectivity_changes_heuristic`)

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] Other validation checks
  - [ ] Decide if skipped checks should be N/A columns or missing altogether
  - [ ] Tests
  - [ ] Sanity checks on performance
  - [ ] Move/remove old functions

## Questions
- [ ] `class QCValidator(BaseClass):` ?
- [ ] spin off into separate repo?

## Status
- [ ] Ready to go