### PR TITLE
Added tmpdir usage for all tests

### DIFF
--- a/openff/benchmark/tests/test_generate_conformers.py
+++ b/openff/benchmark/tests/test_generate_conformers.py
@@ -16,61 +16,63 @@ def test_openeye_deregistered():
     assert isinstance(to_smiles.__self__, RDKitToolkitWrapper)
 
 
-def test_dont_overwrite_output_directory():
-    test_name = inspect.stack()[0].function
-    input_dir = get_data_file_path('1-validate_and_assign_graphs_and_confs')
-    output_dir = os.path.join(test_name, '2-generate_conformers')
-    if os.path.exists(output_dir):
-        shutil.rmtree(output_dir)
-    generate_conformers(input_dir,
-                        output_dir,
-                        )
-    with pytest.raises(Exception, match='delete this manually'):
+def test_dont_overwrite_output_directory(tmpdir):
+    with tmpdir.as_cwd():
+        test_name = inspect.stack()[0].function
+        input_dir = get_data_file_path('1-validate_and_assign_graphs_and_confs')
+        output_dir = os.path.join(test_name, '2-generate_conformers')
+        if os.path.exists(output_dir):
+            shutil.rmtree(output_dir)
         generate_conformers(input_dir,
                             output_dir,
-        )
+                            )
+        with pytest.raises(Exception, match='delete this manually'):
+            generate_conformers(input_dir,
+                                output_dir,
+            )
 
 
 # test loading a mix of graph and 3D molecules, generating up to 10 confs
-def test_generate_conformers():
-    test_name = inspect.stack()[0].function
-    input_dir = get_data_file_path('1-validate_and_assign_graphs_and_confs')
-    output_dir = os.path.join(test_name, '2-generate_conformers')
-    if os.path.exists(output_dir):
-        shutil.rmtree(output_dir)
+def test_generate_conformers(tmpdir):
+    with tmpdir.as_cwd():
+        test_name = inspect.stack()[0].function
+        input_dir = get_data_file_path('1-validate_and_assign_graphs_and_confs')
+        output_dir = os.path.join(test_name, '2-generate_conformers')
+        if os.path.exists(output_dir):
+            shutil.rmtree(output_dir)
+            
+        generate_conformers(input_dir, output_dir)
         
-    generate_conformers(input_dir, output_dir)
-    
-    # Make sure the graph mol is present in the output
-    for mol_idx in range(5):
-        assert os.path.exists(os.path.join(output_dir, f'BBB-{mol_idx:05d}.smi'))
-        # Make sure the mapped smiles is identical before and after
-        input_mapped_smiles = open(os.path.join(input_dir, f'BBB-{mol_idx:05d}.smi')).read()
-        output_mapped_smiles = open(os.path.join(output_dir, f'BBB-{mol_idx:05d}.smi')).read()
-        assert input_mapped_smiles == output_mapped_smiles
-        
-    ## BBB-00000 starts with a smi and two conformers, so many more conformers should be created
-    bbb0_confs = glob.glob(os.path.join(output_dir, 'BBB-00000-*.sdf'))
-    assert len(bbb0_confs) > 3
+        # Make sure the graph mol is present in the output
+        for mol_idx in range(5):
+            assert os.path.exists(os.path.join(output_dir, f'BBB-{mol_idx:05d}.smi'))
+            # Make sure the mapped smiles is identical before and after
+            input_mapped_smiles = open(os.path.join(input_dir, f'BBB-{mol_idx:05d}.smi')).read()
+            output_mapped_smiles = open(os.path.join(output_dir, f'BBB-{mol_idx:05d}.smi')).read()
+            assert input_mapped_smiles == output_mapped_smiles
+            
+        ## BBB-00000 starts with a smi and two conformers, so many more conformers should be created
+        bbb0_confs = glob.glob(os.path.join(output_dir, 'BBB-00000-*.sdf'))
+        assert len(bbb0_confs) > 3
 
-    ## BBB-00001 starts with a smi and one conformer, so many more conformers should be created
-    bbb1_confs = glob.glob(os.path.join(output_dir, 'BBB-00001-*.sdf'))
-    assert len(bbb1_confs) > 2
+        ## BBB-00001 starts with a smi and one conformer, so many more conformers should be created
+        bbb1_confs = glob.glob(os.path.join(output_dir, 'BBB-00001-*.sdf'))
+        assert len(bbb1_confs) > 2
 
-    ## BBB-00002 starts with a smi and NO conformers.
-    # It is rigid so only one conformer should be created
-    bbb2_confs = glob.glob(os.path.join(output_dir, 'BBB-00002-*.sdf'))
-    assert len(bbb2_confs) == 1
+        ## BBB-00002 starts with a smi and NO conformers.
+        # It is rigid so only one conformer should be created
+        bbb2_confs = glob.glob(os.path.join(output_dir, 'BBB-00002-*.sdf'))
+        assert len(bbb2_confs) == 1
 
-    ## BBB-00003 starts with a smi and 12 conformers.
-    # The last two conformers should be pruned and 10 conformers should be output
-    bbb3_confs = glob.glob(os.path.join(output_dir, 'BBB-00003-*.sdf'))
-    assert len(bbb3_confs) == 10
+        ## BBB-00003 starts with a smi and 12 conformers.
+        # The last two conformers should be pruned and 10 conformers should be output
+        bbb3_confs = glob.glob(os.path.join(output_dir, 'BBB-00003-*.sdf'))
+        assert len(bbb3_confs) == 10
 
-    ## BBB-00004 starts with a smi and NO conformers.
-    # It is very flexible so 10 conformers should be output.
-    bbb4_confs = glob.glob(os.path.join(output_dir, 'BBB-00004-*.sdf'))
-    assert len(bbb4_confs) == 10
+        ## BBB-00004 starts with a smi and NO conformers.
+        # It is very flexible so 10 conformers should be output.
+        bbb4_confs = glob.glob(os.path.join(output_dir, 'BBB-00004-*.sdf'))
+        assert len(bbb4_confs) == 10
 
 
 # test loading a molecule with 10 pre-set conformers, so no new confs should be generated

--- a/openff/benchmark/tests/test_validate_and_assign_ids.py
+++ b/openff/benchmark/tests/test_validate_and_assign_ids.py
@@ -15,192 +15,201 @@ def test_openeye_deregistered():
     assert not isinstance(to_smiles.__self__, OpenEyeToolkitWrapper)
     assert isinstance(to_smiles.__self__, RDKitToolkitWrapper)
 
-def test_dont_overwrite_output_directory():
-    test_name = inspect.stack()[0].function
-    test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
-    if os.path.exists(test_dir):
-        shutil.rmtree(test_dir)
-    input_mols = [get_data_file_path('input_single_mol.sdf')]
-    validate_and_assign(input_mols,
-                        '',
-                        'BBB',
-                        test_dir,
-                        )
-    with pytest.raises(Exception, match='delete this manually'):
-        validate_and_assign(input_mols,
-                            '',
-                            'BBB',
-                            test_dir
-                            )
-
-
-# Graph inputs w/o conformers
-class TestGraphInputsWOConformers:
-    # single file single mol
-    def test_single_file_single_mol(self):
-        test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
+def test_dont_overwrite_output_directory(tmpdir):
+    with tmpdir.as_cwd():
+        test_name = inspect.stack()[0].function
         test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
-        #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
         if os.path.exists(test_dir):
             shutil.rmtree(test_dir)
-        #os.makedirs(test_dir)
         input_mols = [get_data_file_path('input_single_mol.sdf')]
         validate_and_assign(input_mols,
                             '',
                             'BBB',
                             test_dir,
                             )
-        output_files = glob.glob(os.path.join(test_dir, '*'))
-        output_files = [os.path.basename(fname) for fname in output_files]
-        assert 'BBB-00000.smi' in output_files
-        assert len(output_files) == 1
-        
-    # single file multi mol
-    def test_single_file_multi_mol(self):
-        test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
-        #raise Exception(inspect.stack()[0].function)
-        test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
-        #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
-        if os.path.exists(test_dir):
-            shutil.rmtree(test_dir)
-        #os.makedirs(test_dir)
-        input_mols = [get_data_file_path('input_multi_mol.sdf')]
-        validate_and_assign(input_mols,
-                            '',
-                            'BBB',
-                            test_dir,
-                            )
-        output_files = glob.glob(os.path.join(test_dir, '*'))
-        output_files = [os.path.basename(fname) for fname in output_files]
-        assert 'BBB-00000.smi' in output_files
-        assert 'BBB-00003.smi' in output_files
-        assert len(output_files) == 4
-        
-    # multi file single mol
-    def test_multi_file_single_mol(self):
-        test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
-        #raise Exception(inspect.stack()[0].function)
-        test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
-        #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
-        if os.path.exists(test_dir):
-            shutil.rmtree(test_dir)
-        #os.makedirs(test_dir)
-        input_mols = [get_data_file_path('input_single_mol.sdf'),
-                      get_data_file_path('input_one_stereoisomer.sdf')]
-        validate_and_assign(input_mols,
-                            '',
-                            'BBB',
-                            test_dir,
-                            )
-        output_files = glob.glob(os.path.join(test_dir, '*'))
-        output_files = [os.path.basename(fname) for fname in output_files]
-        assert 'BBB-00000.smi' in output_files
-        assert 'BBB-00001.smi' in output_files
-        assert len(output_files) == 2
-        
-    # multi file multi mol
-    def test_multi_file_multi_mol(self):
-        test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
-        #raise Exception(inspect.stack()[0].function)
-        test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
-        #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
-        if os.path.exists(test_dir):
-            shutil.rmtree(test_dir)
-        #os.makedirs(test_dir)
-        input_mols = [get_data_file_path('input_multi_mol.sdf'),
-                      get_data_file_path('input_all_stereoisomers.sdf')]
-        validate_and_assign(input_mols,
-                            '',
-                            'BBB',
-                            test_dir,
-                            )
-        output_files = glob.glob(os.path.join(test_dir, '*'))
-        output_files = [os.path.basename(fname) for fname in output_files]
-        assert 'BBB-00000.smi' in output_files
-        assert 'BBB-00011.smi' in output_files
-        assert len(output_files) == 12
-        
-    # single file multi mol duplicates (error)
-    def test_single_file_multi_mol_duplicate_error(self):
-        test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
-        #raise Exception(inspect.stack()[0].function)
-        test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
-        #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
-        if os.path.exists(test_dir):
-            shutil.rmtree(test_dir)
-        #os.makedirs(test_dir)
-        input_mols = [get_data_file_path('input_duplicates.sdf')]
-        with pytest.raises(Exception, match='Duplicate'):
+        with pytest.raises(Exception, match='delete this manually'):
             validate_and_assign(input_mols,
                                 '',
                                 'BBB',
                                 test_dir
                                 )
+
+
+# Graph inputs w/o conformers
+class TestGraphInputsWOConformers:
+    # single file single mol
+    def test_single_file_single_mol(self, tmpdir):
+        with tmpdir.as_cwd():
+            test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
+            test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
+            #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
+            if os.path.exists(test_dir):
+                shutil.rmtree(test_dir)
+            #os.makedirs(test_dir)
+            input_mols = [get_data_file_path('input_single_mol.sdf')]
+            validate_and_assign(input_mols,
+                                '',
+                                'BBB',
+                                test_dir,
+                                )
+            output_files = glob.glob(os.path.join(test_dir, '*'))
+            output_files = [os.path.basename(fname) for fname in output_files]
+            assert 'BBB-00000.smi' in output_files
+            assert len(output_files) == 1
+        
+    # single file multi mol
+    def test_single_file_multi_mol(self, tmpdir):
+        with tmpdir.as_cwd():
+            test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
+            #raise Exception(inspect.stack()[0].function)
+            test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
+            #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
+            if os.path.exists(test_dir):
+                shutil.rmtree(test_dir)
+            #os.makedirs(test_dir)
+            input_mols = [get_data_file_path('input_multi_mol.sdf')]
+            validate_and_assign(input_mols,
+                                '',
+                                'BBB',
+                                test_dir,
+                                )
+            output_files = glob.glob(os.path.join(test_dir, '*'))
+            output_files = [os.path.basename(fname) for fname in output_files]
+            assert 'BBB-00000.smi' in output_files
+            assert 'BBB-00003.smi' in output_files
+            assert len(output_files) == 4
+        
+    # multi file single mol
+    def test_multi_file_single_mol(self, tmpdir):
+        with tmpdir.as_cwd():
+            test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
+            #raise Exception(inspect.stack()[0].function)
+            test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
+            #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
+            if os.path.exists(test_dir):
+                shutil.rmtree(test_dir)
+            #os.makedirs(test_dir)
+            input_mols = [get_data_file_path('input_single_mol.sdf'),
+                          get_data_file_path('input_one_stereoisomer.sdf')]
+            validate_and_assign(input_mols,
+                                '',
+                                'BBB',
+                                test_dir,
+                                )
+            output_files = glob.glob(os.path.join(test_dir, '*'))
+            output_files = [os.path.basename(fname) for fname in output_files]
+            assert 'BBB-00000.smi' in output_files
+            assert 'BBB-00001.smi' in output_files
+            assert len(output_files) == 2
+        
+    # multi file multi mol
+    def test_multi_file_multi_mol(self, tmpdir):
+        with tmpdir.as_cwd():
+            test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
+            #raise Exception(inspect.stack()[0].function)
+            test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
+            #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
+            if os.path.exists(test_dir):
+                shutil.rmtree(test_dir)
+            #os.makedirs(test_dir)
+            input_mols = [get_data_file_path('input_multi_mol.sdf'),
+                          get_data_file_path('input_all_stereoisomers.sdf')]
+            validate_and_assign(input_mols,
+                                '',
+                                'BBB',
+                                test_dir,
+                                )
+            output_files = glob.glob(os.path.join(test_dir, '*'))
+            output_files = [os.path.basename(fname) for fname in output_files]
+            assert 'BBB-00000.smi' in output_files
+            assert 'BBB-00011.smi' in output_files
+            assert len(output_files) == 12
+        
+    # single file multi mol duplicates (error)
+    def test_single_file_multi_mol_duplicate_error(self, tmpdir):
+        with tmpdir.as_cwd():
+            test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
+            #raise Exception(inspect.stack()[0].function)
+            test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
+            #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
+            if os.path.exists(test_dir):
+                shutil.rmtree(test_dir)
+            #os.makedirs(test_dir)
+            input_mols = [get_data_file_path('input_duplicates.sdf')]
+            with pytest.raises(Exception, match='Duplicate'):
+                validate_and_assign(input_mols,
+                                    '',
+                                    'BBB',
+                                    test_dir
+                                    )
             
     # multi file multi mol duplicates (error)
-    def test_multi_file_multi_mol_duplicate_error(self):
-        test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
-        #raise Exception(inspect.stack()[0].function)
-        test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
-        #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
-        if os.path.exists(test_dir):
-            shutil.rmtree(test_dir)
-        #os.makedirs(test_dir)
-        input_mols = [get_data_file_path('input_one_stereoisomer.sdf'),
-                      get_data_file_path('input_all_stereoisomers.sdf')]
-        with pytest.raises(Exception, match='Duplicate'):
-            validate_and_assign(input_mols,
-                                '',
-                                'BBB',
-                                test_dir,
-                                )
+    def test_multi_file_multi_mol_duplicate_error(self, tmpdir):
+        with tmpdir.as_cwd():
+            test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
+            #raise Exception(inspect.stack()[0].function)
+            test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
+            #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
+            if os.path.exists(test_dir):
+                shutil.rmtree(test_dir)
+            #os.makedirs(test_dir)
+            input_mols = [get_data_file_path('input_one_stereoisomer.sdf'),
+                          get_data_file_path('input_all_stereoisomers.sdf')]
+            with pytest.raises(Exception, match='Duplicate'):
+                validate_and_assign(input_mols,
+                                    '',
+                                    'BBB',
+                                    test_dir,
+                                    )
             
     # input undefined stereochemistry (error)
-    def test_undefined_stereochemistry(self):
-        test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
-        #raise Exception(inspect.stack()[0].function)
-        test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
-        #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
-        if os.path.exists(test_dir):
-            shutil.rmtree(test_dir)
-        #os.makedirs(test_dir)
-        input_mols = [get_data_file_path('input_2d.sdf')]
-        with pytest.raises(Exception, match='stereo'):
-            validate_and_assign(input_mols,
-                                '',
-                                'BBB',
-                                test_dir,
-                                )
+    def test_undefined_stereochemistry(self, tmpdir):
+        with tmpdir.as_cwd():
+            test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
+            #raise Exception(inspect.stack()[0].function)
+            test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
+            #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
+            if os.path.exists(test_dir):
+                shutil.rmtree(test_dir)
+            #os.makedirs(test_dir)
+            input_mols = [get_data_file_path('input_2d.sdf')]
+            with pytest.raises(Exception, match='stereo'):
+                validate_and_assign(input_mols,
+                                    '',
+                                    'BBB',
+                                    test_dir,
+                                    )
 
 # Conformers w/o graphs
 class Test3dInputsWOGraphs:
     # single file single mol
-    def test_single_file_single_mol(self):
-        test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
-        test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
-        #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
-        if os.path.exists(test_dir):
-            shutil.rmtree(test_dir)
-        #os.makedirs(test_dir)
-        input_mols = [get_data_file_path('input_single_mol.sdf')]
-        validate_and_assign('',
-                            input_mols,
-                            'BBB',
-                            test_dir,
-                            )
-        output_files = glob.glob(os.path.join(test_dir, '*'))
-        output_files = [os.path.basename(fname) for fname in output_files]
-        assert 'BBB-00000.smi' in output_files
-        assert 'BBB-00000-00.sdf' in output_files
-        assert len(output_files) == 2
-        file_text = open(os.path.join(test_dir, 'BBB-00000-00.sdf')).read()
-        assert """
+    def test_single_file_single_mol(self, tmpdir):
+        with tmpdir.as_cwd():
+            test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
+            test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
+            #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
+            if os.path.exists(test_dir):
+                shutil.rmtree(test_dir)
+            #os.makedirs(test_dir)
+            input_mols = [get_data_file_path('input_single_mol.sdf')]
+            validate_and_assign('',
+                                input_mols,
+                                'BBB',
+                                test_dir,
+                                )
+            output_files = glob.glob(os.path.join(test_dir, '*'))
+            output_files = [os.path.basename(fname) for fname in output_files]
+            assert 'BBB-00000.smi' in output_files
+            assert 'BBB-00000-00.sdf' in output_files
+            assert len(output_files) == 2
+            file_text = open(os.path.join(test_dir, 'BBB-00000-00.sdf')).read()
+            assert """
 >  <group_name>  (1) 
 BBB""" in file_text
-        assert """
+            assert """
 >  <molecule_index>  (1) 
 0""" in file_text
-        assert """
+            assert """
 >  <conformer_index>  (1) 
 0""" in file_text
         
@@ -208,193 +217,201 @@ BBB""" in file_text
                          
     
     # single file multi mol
-    def test_single_file_multi_mol(self):
-        test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
-        test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
-        #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
-        if os.path.exists(test_dir):
-            shutil.rmtree(test_dir)
-        #os.makedirs(test_dir)
-        input_mols = [get_data_file_path('input_multi_mol.sdf')]
-        validate_and_assign('',
-                            input_mols,
-                            'BBB',
-                            test_dir,
-                            )
-        output_files = glob.glob(os.path.join(test_dir, '*'))
-        output_files = [os.path.basename(fname) for fname in output_files]
-        assert 'BBB-00000.smi' in output_files
-        assert 'BBB-00003.smi' in output_files
-        assert 'BBB-00000-00.sdf' in output_files
-        assert 'BBB-00003-00.sdf' in output_files
-        assert len(output_files) == 8
+    def test_single_file_multi_mol(self, tmpdir):
+        with tmpdir.as_cwd():
+            test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
+            test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
+            #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
+            if os.path.exists(test_dir):
+                shutil.rmtree(test_dir)
+            #os.makedirs(test_dir)
+            input_mols = [get_data_file_path('input_multi_mol.sdf')]
+            validate_and_assign('',
+                                input_mols,
+                                'BBB',
+                                test_dir,
+                                )
+            output_files = glob.glob(os.path.join(test_dir, '*'))
+            output_files = [os.path.basename(fname) for fname in output_files]
+            assert 'BBB-00000.smi' in output_files
+            assert 'BBB-00003.smi' in output_files
+            assert 'BBB-00000-00.sdf' in output_files
+            assert 'BBB-00003-00.sdf' in output_files
+            assert len(output_files) == 8
         
     # single file multi conformer
-    def test_single_file_multi_conformer(self):
-        test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
-        test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
-        #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
-        if os.path.exists(test_dir):
-            shutil.rmtree(test_dir)
-        #os.makedirs(test_dir)
-        input_mols = [get_data_file_path('input_duplicates.sdf')]
-        validate_and_assign('',
-                            input_mols,
-                            'BBB',
-                            test_dir,
-                            )
-        output_files = glob.glob(os.path.join(test_dir, '*'))
-        output_files = [os.path.basename(fname) for fname in output_files]
-        assert 'BBB-00000.smi' in output_files
-        assert 'BBB-00000-00.sdf' in output_files
-        assert 'BBB-00000-09.sdf' in output_files
-        assert len(output_files) == 11
+    def test_single_file_multi_conformer(self, tmpdir):
+        with tmpdir.as_cwd():
+            test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
+            test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
+            #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
+            if os.path.exists(test_dir):
+                shutil.rmtree(test_dir)
+            #os.makedirs(test_dir)
+            input_mols = [get_data_file_path('input_duplicates.sdf')]
+            validate_and_assign('',
+                                input_mols,
+                                'BBB',
+                                test_dir,
+                                )
+            output_files = glob.glob(os.path.join(test_dir, '*'))
+            output_files = [os.path.basename(fname) for fname in output_files]
+            assert 'BBB-00000.smi' in output_files
+            assert 'BBB-00000-00.sdf' in output_files
+            assert 'BBB-00000-09.sdf' in output_files
+            assert len(output_files) == 11
         
     # multi file single mol
-    def test_multi_file_single_mol(self):
-        test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
-        test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
-        #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
-        if os.path.exists(test_dir):
-            shutil.rmtree(test_dir)
-        #os.makedirs(test_dir)
-        input_mols = [get_data_file_path('input_single_mol.sdf'),
-                      get_data_file_path('input_one_stereoisomer.sdf')]
-        validate_and_assign('',
-                            input_mols,
-                            'BBB',
-                            test_dir,
-                            )
-        output_files = glob.glob(os.path.join(test_dir, '*'))
-        output_files = [os.path.basename(fname) for fname in output_files]
-        assert 'BBB-00000.smi' in output_files
-        assert 'BBB-00001.smi' in output_files
-        assert 'BBB-00000-00.sdf' in output_files
-        assert 'BBB-00001-00.sdf' in output_files
-        assert len(output_files) == 4
+    def test_multi_file_single_mol(self, tmpdir):
+        with tmpdir.as_cwd():
+            test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
+            test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
+            #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
+            if os.path.exists(test_dir):
+                shutil.rmtree(test_dir)
+            #os.makedirs(test_dir)
+            input_mols = [get_data_file_path('input_single_mol.sdf'),
+                          get_data_file_path('input_one_stereoisomer.sdf')]
+            validate_and_assign('',
+                                input_mols,
+                                'BBB',
+                                test_dir,
+                                )
+            output_files = glob.glob(os.path.join(test_dir, '*'))
+            output_files = [os.path.basename(fname) for fname in output_files]
+            assert 'BBB-00000.smi' in output_files
+            assert 'BBB-00001.smi' in output_files
+            assert 'BBB-00000-00.sdf' in output_files
+            assert 'BBB-00001-00.sdf' in output_files
+            assert len(output_files) == 4
         
     # multi file multi mol
-    def test_multi_file_multi_mol(self):
-        test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
-        test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
-        #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
-        if os.path.exists(test_dir):
-            shutil.rmtree(test_dir)
-        #os.makedirs(test_dir)
-        input_mols = [get_data_file_path('input_multi_mol.sdf'),
-                      get_data_file_path('input_all_stereoisomers.sdf')]
-        validate_and_assign('',
-                            input_mols,
-                            'BBB',
-                            test_dir,
-                            )
-        output_files = glob.glob(os.path.join(test_dir, '*'))
-        output_files = [os.path.basename(fname) for fname in output_files]
-        assert 'BBB-00000.smi' in output_files
-        assert 'BBB-00011.smi' in output_files
-        assert 'BBB-00012.smi' not in output_files
-        assert 'BBB-00000-00.sdf' in output_files
-        assert 'BBB-00011-00.sdf' in output_files
-        assert len(output_files) == 24
+    def test_multi_file_multi_mol(self, tmpdir):
+        with tmpdir.as_cwd():
+            test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
+            test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
+            #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
+            if os.path.exists(test_dir):
+                shutil.rmtree(test_dir)
+            #os.makedirs(test_dir)
+            input_mols = [get_data_file_path('input_multi_mol.sdf'),
+                          get_data_file_path('input_all_stereoisomers.sdf')]
+            validate_and_assign('',
+                                input_mols,
+                                'BBB',
+                                test_dir,
+                                )
+            output_files = glob.glob(os.path.join(test_dir, '*'))
+            output_files = [os.path.basename(fname) for fname in output_files]
+            assert 'BBB-00000.smi' in output_files
+            assert 'BBB-00011.smi' in output_files
+            assert 'BBB-00012.smi' not in output_files
+            assert 'BBB-00000-00.sdf' in output_files
+            assert 'BBB-00011-00.sdf' in output_files
+            assert len(output_files) == 24
 
     # multi file multi mol duplicates (ok)
-    def test_multi_file_multi_mol_duplicates(self):
-        #raise Exception(inspect.stack()[0])
-        #test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
-        test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
-        test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
-        #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
-        if os.path.exists(test_dir):
-            shutil.rmtree(test_dir)
-        #os.makedirs(test_dir)
-        input_mols = [get_data_file_path('input_one_stereoisomer.sdf'),
-                      get_data_file_path('input_all_stereoisomers.sdf')]
-        validate_and_assign('',
-                            input_mols,
-                            'BBB',
-                            test_dir,
-                            )
-        output_files = glob.glob(os.path.join(test_dir, '*'))
-        output_files = [os.path.basename(fname) for fname in output_files]
-        assert 'BBB-00000.smi' in output_files
-        assert 'BBB-00007.smi' in output_files
-        assert 'BBB-00000-00.sdf' in output_files
-        assert 'BBB-00000-01.sdf' in output_files
-        assert 'BBB-00001-00.sdf' in output_files
-        assert 'BBB-00001-01.sdf' not in output_files
-        assert len(output_files) == 8 + 9
+    def test_multi_file_multi_mol_duplicates(self, tmpdir):
+        with tmpdir.as_cwd():
+            #raise Exception(inspect.stack()[0])
+            #test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
+            test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
+            test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
+            #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
+            if os.path.exists(test_dir):
+                shutil.rmtree(test_dir)
+            #os.makedirs(test_dir)
+            input_mols = [get_data_file_path('input_one_stereoisomer.sdf'),
+                          get_data_file_path('input_all_stereoisomers.sdf')]
+            validate_and_assign('',
+                                input_mols,
+                                'BBB',
+                                test_dir,
+                                )
+            output_files = glob.glob(os.path.join(test_dir, '*'))
+            output_files = [os.path.basename(fname) for fname in output_files]
+            assert 'BBB-00000.smi' in output_files
+            assert 'BBB-00007.smi' in output_files
+            assert 'BBB-00000-00.sdf' in output_files
+            assert 'BBB-00000-01.sdf' in output_files
+            assert 'BBB-00001-00.sdf' in output_files
+            assert 'BBB-00001-01.sdf' not in output_files
+            assert len(output_files) == 8 + 9
 
 #
 # Conformers w graphs
 class TestGraphAnd3dInputs:
     # no overlap
-    def test_no_overlap(self):
-        test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
-        test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
-        #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
-        if os.path.exists(test_dir):
-            shutil.rmtree(test_dir)
-        #os.makedirs(test_dir)
-        input_graphs = [get_data_file_path('input_single_mol.sdf')]
-        input_3ds = [get_data_file_path('input_one_stereoisomer.sdf')]
-        validate_and_assign(input_graphs,
-                            input_3ds,
-                            'BBB',
-                            test_dir,
-                            )
-        output_files = glob.glob(os.path.join(test_dir, '*'))
-        output_files = [os.path.basename(fname) for fname in output_files]
-        assert 'BBB-00000.smi' in output_files
-        assert 'BBB-00000-00.sdf' not in output_files
-        assert 'BBB-00001.smi' in output_files
-        assert 'BBB-00001-00.sdf' in output_files
-        assert len(output_files) == 3
+    def test_no_overlap(self, tmpdir):
+        with tmpdir.as_cwd():
+            test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
+            test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
+            #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
+            if os.path.exists(test_dir):
+                shutil.rmtree(test_dir)
+            #os.makedirs(test_dir)
+            input_graphs = [get_data_file_path('input_single_mol.sdf')]
+            input_3ds = [get_data_file_path('input_one_stereoisomer.sdf')]
+            validate_and_assign(input_graphs,
+                                input_3ds,
+                                'BBB',
+                                test_dir,
+                                )
+            output_files = glob.glob(os.path.join(test_dir, '*'))
+            output_files = [os.path.basename(fname) for fname in output_files]
+            assert 'BBB-00000.smi' in output_files
+            assert 'BBB-00000-00.sdf' not in output_files
+            assert 'BBB-00001.smi' in output_files
+            assert 'BBB-00001-00.sdf' in output_files
+            assert len(output_files) == 3
         
     # graphs superset of conformers
-    def test_graphs_superset_of_conformers(self):
-        test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
-        test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
-        #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
-        if os.path.exists(test_dir):
-            shutil.rmtree(test_dir)
-        #os.makedirs(test_dir)
-        input_graphs = [get_data_file_path('input_single_mol.sdf'),
-                        get_data_file_path('input_one_stereoisomer.sdf')]
-        input_3ds = [get_data_file_path('input_one_stereoisomer.sdf')]
-        validate_and_assign(input_graphs,
-                            input_3ds,
-                            'BBB',
-                            test_dir,
-                            )
-        output_files = glob.glob(os.path.join(test_dir, '*'))
-        output_files = [os.path.basename(fname) for fname in output_files]
-        assert 'BBB-00000.smi' in output_files
-        assert 'BBB-00000-00.sdf' not in output_files
-        assert 'BBB-00001.smi' in output_files
-        assert 'BBB-00001-00.sdf' in output_files
-        assert len(output_files) == 3
+    def test_graphs_superset_of_conformers(self, tmpdir):
+        with tmpdir.as_cwd():
+            test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
+            test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
+            #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
+            if os.path.exists(test_dir):
+                shutil.rmtree(test_dir)
+            #os.makedirs(test_dir)
+            input_graphs = [get_data_file_path('input_single_mol.sdf'),
+                            get_data_file_path('input_one_stereoisomer.sdf')]
+            input_3ds = [get_data_file_path('input_one_stereoisomer.sdf')]
+            validate_and_assign(input_graphs,
+                                input_3ds,
+                                'BBB',
+                                test_dir,
+                                )
+            output_files = glob.glob(os.path.join(test_dir, '*'))
+            output_files = [os.path.basename(fname) for fname in output_files]
+            assert 'BBB-00000.smi' in output_files
+            assert 'BBB-00000-00.sdf' not in output_files
+            assert 'BBB-00001.smi' in output_files
+            assert 'BBB-00001-00.sdf' in output_files
+            assert len(output_files) == 3
         
     # conformers superset of graphs
-    def test_conformers_superset_of_graphs(self):
-        test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
-        test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
-        #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
-        if os.path.exists(test_dir):
-            shutil.rmtree(test_dir)
-        #os.makedirs(test_dir)
-        input_graphs = [get_data_file_path('input_single_mol.sdf')]
-        input_3ds = [get_data_file_path('input_one_stereoisomer.sdf'),
-                     get_data_file_path('input_single_mol.sdf')]
-        validate_and_assign(input_graphs,
-                            input_3ds,
-                            'BBB',
-                            test_dir,
-                            )
-        output_files = glob.glob(os.path.join(test_dir, '*'))
-        output_files = [os.path.basename(fname) for fname in output_files]
-        assert 'BBB-00000.smi' in output_files
-        assert 'BBB-00000-00.sdf' in output_files
-        assert 'BBB-00001.smi' in output_files
-        assert 'BBB-00001-00.sdf' in output_files
-        assert len(output_files) == 4
+    def test_conformers_superset_of_graphs(self, tmpdir):
+        with tmpdir.as_cwd():
+            test_name = f'{self.__class__.__name__}.{inspect.stack()[0].function}'
+            test_dir = os.path.join(test_name, '1-validate_and_assign_graphs_and_confs')
+            #test_dir = 'test_multi_molecule_multi_sdf_graph_input'
+            if os.path.exists(test_dir):
+                shutil.rmtree(test_dir)
+            #os.makedirs(test_dir)
+            input_graphs = [get_data_file_path('input_single_mol.sdf')]
+            input_3ds = [get_data_file_path('input_one_stereoisomer.sdf'),
+                         get_data_file_path('input_single_mol.sdf')]
+            validate_and_assign(input_graphs,
+                                input_3ds,
+                                'BBB',
+                                test_dir,
+                                )
+            output_files = glob.glob(os.path.join(test_dir, '*'))
+            output_files = [os.path.basename(fname) for fname in output_files]
+            assert 'BBB-00000.smi' in output_files
+            assert 'BBB-00000-00.sdf' in output_files
+            assert 'BBB-00001.smi' in output_files
+            assert 'BBB-00001-00.sdf' in output_files
+            assert len(output_files) == 4
         


### PR DESCRIPTION
## Description
Avoids pollution of the repo space from test execution; file outputs are placed in the system temporary directory (`/tmp` on most Linuxes).