### PR TITLE
Conformer performance

### DIFF
--- a/openff/benchmark/cli.py
+++ b/openff/benchmark/cli.py
@@ -203,6 +203,7 @@ def validate(input_3d_molecules, output_directory, group_name, delete_existing):
 @click.option('-o', '--output-directory',
               default='2-generate_conformers', 
               help='Directory for output files. If this directory does not exist, one will be created.')
+@click.option("--processors", default=None, help="The number of processors that can be used when generating the conformers, if nothing is supplied all will be used.")
 @click.argument('input-directory')
 def generate_conformers(input_directory, output_directory, delete_existing):
     """Generate additional conformers for validated molecules.

--- a/openff/benchmark/utils/generate_conformers.py
+++ b/openff/benchmark/utils/generate_conformers.py
@@ -148,7 +148,6 @@ def gen_confs_preserving_orig_confs(conformer_mols,
     ------
     
     """
-    
     logging.info(f"Generating conformers for {conformer_mols['00'].name}")
     
     # If there are already enough conformers, just return immediately
@@ -162,50 +161,52 @@ def gen_confs_preserving_orig_confs(conformer_mols,
     sorted_conf_idxs = sorted([i for i in conformer_mols.keys()])
     for conf_idx in sorted_conf_idxs[1:]:
         mol.add_conformer(conformer_mols[conf_idx].conformers[0])
-    
-    # Generate a large number of candidate conformers
-    mol.generate_conformers(n_conformers=5 * target_n_confs,
-                            # Multiply by 1.5 because this RMSD include hydrogens
-                            rms_cutoff=min_rmsd * 1.5 * unit.angstrom, 
-                            clear_existing=False)
-    
-    mol, rmslist = align_offmol_conformers(mol)
-    
-    # Run the "RMSD ratchet", increasing the RMS cutoff until we have a number
-    # of conformers equal to or less than the target number
-    logging.info(f'initially {mol.n_conformers} conformers, {n_user_confs} are from user')
-    rmsd_cutoff = min_rmsd
-    confs_to_delete = None
-    while True:
-        confs_to_delete = greedy_conf_deduplication(mol, 
-                                                    rmsd_cutoff, 
-                                                    user_confs=range(n_user_confs))
-        n_remaining_confs = mol.n_conformers - len(confs_to_delete)
-        logging.info(f'rms_cutoff {rmsd_cutoff:0.2f}: {n_remaining_confs} confs remain')
-        if n_remaining_confs <= target_n_confs:
-            logging.info(f'Target number of conformers reached. Stopping iteration.')
-            break
-        rmsd_cutoff += rmsd_step
-    
-    # Unpack the conformers back to OFFMols, skipping those which should 
-    # be deleted from the output
-    output_mols = {}
-    confs_to_write = [i for i in range(mol.n_conformers) if i not in confs_to_delete]
-    logging.info(f'conformers to write are {confs_to_write}')
-    for output_conf_index, generated_conf_index in enumerate(confs_to_write):
-        new_mol = copy.deepcopy(mol)
-        new_mol._conformers = []
-        new_mol.add_conformer(mol.conformers[generated_conf_index])
-        new_mol.name = mol.name
-        new_mol.properties['conformer_index'] = output_conf_index
-        output_mols[f'{output_conf_index:02d}'] = new_mol
-    
+
+    try:
+        # Generate a large number of candidate conformers
+        mol.generate_conformers(n_conformers=5 * target_n_confs,
+                                # Multiply by 1.5 because this RMSD include hydrogens
+                                rms_cutoff=min_rmsd * 1.5 * unit.angstrom,
+                                clear_existing=False)
+
+        mol, rmslist = align_offmol_conformers(mol)
+
+        # Run the "RMSD ratchet", increasing the RMS cutoff until we have a number
+        # of conformers equal to or less than the target number
+        logging.info(f'initially {mol.n_conformers} conformers, {n_user_confs} are from user')
+        rmsd_cutoff = min_rmsd
+        confs_to_delete = None
+        while True:
+            confs_to_delete = greedy_conf_deduplication(mol,
+                                                        rmsd_cutoff,
+                                                        user_confs=range(n_user_confs))
+            n_remaining_confs = mol.n_conformers - len(confs_to_delete)
+            logging.info(f'rms_cutoff {rmsd_cutoff:0.2f}: {n_remaining_confs} confs remain')
+            if n_remaining_confs <= target_n_confs:
+                logging.info(f'Target number of conformers reached. Stopping iteration.')
+                break
+            rmsd_cutoff += rmsd_step
+
+        # Unpack the conformers back to OFFMols, skipping those which should
+        # be deleted from the output
+        output_mols = {}
+        confs_to_write = [i for i in range(mol.n_conformers) if i not in confs_to_delete]
+        logging.info(f'conformers to write are {confs_to_write}')
+        for output_conf_index, generated_conf_index in enumerate(confs_to_write):
+            new_mol = copy.deepcopy(mol)
+            new_mol._conformers = []
+            new_mol.add_conformer(mol.conformers[generated_conf_index])
+            new_mol.name = mol.name
+            new_mol.properties['conformer_index'] = output_conf_index
+            output_mols[f'{output_conf_index:02d}'] = new_mol
+    except Exception as e:
+        return {"error": e, "input_mols": conformer_mols}
     return output_mols    
         
     
 
-def generate_conformers(input_directory, output_directory, delete_existing=False):
-
+def generate_conformers(input_directory, output_directory, delete_existing=False, processors=None):
+    from multiprocessing.pool import Pool
     try:
         os.makedirs(output_directory)
     except OSError:
@@ -232,12 +233,12 @@ def generate_conformers(input_directory, output_directory, delete_existing=False
         mol = Molecule.from_file(input_3d_file, allow_undefined_stereo=True)
         #except:
         #    raise Exception(input_3d_file)
-        match = re.findall('([a-zA-Z0-9]{3})-([0-9]{5})-([0-9]{2}).sdf',
-                           input_3d_file)
-        assert len(match) == 1
-        group_id = match[0][0]
-        mol_idx = match[0][1]
-        conf_id = match[0][2]
+        # match = re.findall('([a-zA-Z0-9]{3})-([0-9]{5})-([0-9]{2}).sdf',
+        #                    input_3d_file)
+        # assert len(match) == 1
+        group_id = mol.properties["group_name"] # match[0][0]
+        mol_idx = f'{mol.properties["molecule_index"]:04}' # match[0][1]
+        conf_id = f'{mol.properties["conformer_index"]:02}'  # match[0][2]
         if group_id not in group2idx2mols2confs:
             group2idx2mols2confs[group_id] = {}
         if mol_idx not in group2idx2mols2confs[group_id]:
@@ -258,43 +259,80 @@ def generate_conformers(input_directory, output_directory, delete_existing=False
     for group_id in sorted_group_ids:
         print(f'Processing group {group_id}')
         sorted_mol_ids = sorted(list(group2idx2mols2confs[group_id].keys()))
-        for mol_idx in tqdm(sorted_mol_ids):
-            try:
-                conf_dict = group2idx2mols2confs[group_id][mol_idx]
-                output_confs = gen_confs_preserving_orig_confs(conf_dict,
-                                                               target_n_confs=10,
-                                                               min_rmsd=1)
-                group2idx2mols2confs[group_id][mol_idx] = output_confs
-            except Exception as e:
-                mol_id = f'{group_id}-{mol_idx}'
-                logging.info(f'Error [{e}] for molecule {mol_id}. Writing to error_mols')
-                try:
-                    for conf_idx in group2idx2mols2confs[group_id][mol_idx]:
-                        conf_file = f'{mol_id}-{int(conf_idx):02d}.sdf'
-                        conf_mol = group2idx2mols2confs[group_id][mol_idx][conf_idx]
-                        conf_mol.to_file(os.path.join(error_dir, conf_file), file_format='sdf')
-                except Exception as e2:
-                    logging.info(f'Unable to write all error structures to file. Encountered error [{e}]')
-                    e = str(e) + '\n Then, when trying to write out the conformers:\n' + str(e2)
-                    
-                with open(os.path.join(error_dir, f'{mol_id}.txt'), 'w') as of:
-                    of.write(str(e))
-                del group2idx2mols2confs[group_id][mol_idx]
-                continue
+        with Pool(processes=processors) as pool:
+            # send each molecule to a process to gen the conformers
+            work_list = [
+                pool.apply_async(gen_confs_preserving_orig_confs, (group2idx2mols2confs[group_id][mol_idx], 10, 1))
+                for mol_idx in sorted_mol_ids
+            ]
+            for work in tqdm(
+                    work_list,
+                    total=len(work_list),
+                    ncols=80,
+                    desc="{:30s}".format("Generating Conformers"),
+            ):
+                work = work.get()
+                if "error" in work:
+                    mol = work["input_mols"]["00"]
+                    group_id = mol.properties["group_name"]
+                    mol_idx = f'{mol.properties["molecule_index"]:02}'
+                    mol_id = f'{group_id}-{mol_idx}'
+                    logging.info(f'Error [{work["error"]}] for molecule {mol_id}. Writing to error_mols')
+                    try:
+                        for conf_idx in group2idx2mols2confs[group_id][mol_idx]:
+                            conf_file = f'{mol_id}-{int(conf_idx):02d}.sdf'
+                            conf_mol = group2idx2mols2confs[group_id][mol_idx][conf_idx]
+                            conf_mol.to_file(os.path.join(error_dir, conf_file), file_format='sdf')
+                    except Exception as e2:
+                        logging.info(f'Unable to write all error structures to file. Encountered error [{e}]')
+                        e = str(e) + '\n Then, when trying to write out the conformers:\n' + str(e2)
+
+                    with open(os.path.join(error_dir, f'{mol_id}.txt'), 'w') as of:
+                        of.write(str(e))
+                    del group2idx2mols2confs[group_id][mol_idx]
+                    continue
+                else:
+                    mol = work["00"]
+                    group_id = mol.properties["group_name"]
+                    mol_idx = f'{mol.properties["molecule_index"]:02}'
+                    group2idx2mols2confs[group_id][mol_idx] = work
+        # for mol_idx in tqdm(sorted_mol_ids):
+        #     try:
+        #         conf_dict = group2idx2mols2confs[group_id][mol_idx]
+        #         output_confs = gen_confs_preserving_orig_confs(conf_dict,
+        #                                                        target_n_confs=10,
+        #                                                        min_rmsd=1)
+        #         group2idx2mols2confs[group_id][mol_idx] = output_confs
+        #     except Exception as e:
+        #         mol_id = f'{group_id}-{mol_idx}'
+        #         logging.info(f'Error [{e}] for molecule {mol_id}. Writing to error_mols')
+        #         try:
+        #             for conf_idx in group2idx2mols2confs[group_id][mol_idx]:
+        #                 conf_file = f'{mol_id}-{int(conf_idx):02d}.sdf'
+        #                 conf_mol = group2idx2mols2confs[group_id][mol_idx][conf_idx]
+        #                 conf_mol.to_file(os.path.join(error_dir, conf_file), file_format='sdf')
+        #         except Exception as e2:
+        #             logging.info(f'Unable to write all error structures to file. Encountered error [{e}]')
+        #             e = str(e) + '\n Then, when trying to write out the conformers:\n' + str(e2)
+        #
+        #         with open(os.path.join(error_dir, f'{mol_id}.txt'), 'w') as of:
+        #             of.write(str(e))
+        #         del group2idx2mols2confs[group_id][mol_idx]
+        #         continue
 
     # Write outputs
     #for group_id in group2idx2mols2confs:
-    #    for mol_idx in group2idx2mols2confs[group_id]:
-            for conf_idx in group2idx2mols2confs[group_id][mol_idx]:
-                mol_name = f'{group_id}-{int(mol_idx):05d}'
-                this_conf = group2idx2mols2confs[group_id][mol_idx][conf_idx]
-                this_conf.properties['group_name'] = group_id
-                this_conf.properties['molecule_index'] = mol_idx
-                this_conf.name = mol_name
-                
-                this_conf.properties['conformer_index'] = conf_idx
-                out_file_name = f'{this_conf.name}-{int(conf_idx):02d}.sdf'
-                this_conf.to_file(os.path.join(output_directory, out_file_name), file_format='sdf')
+            for mol_idx in group2idx2mols2confs[group_id]:
+                for conf_idx in group2idx2mols2confs[group_id][mol_idx]:
+                    mol_name = f'{group_id}-{int(mol_idx):05d}'
+                    this_conf = group2idx2mols2confs[group_id][mol_idx][conf_idx]
+                    this_conf.properties['group_name'] = group_id
+                    this_conf.properties['molecule_index'] = mol_idx
+                    this_conf.name = mol_name
+
+                    this_conf.properties['conformer_index'] = conf_idx
+                    out_file_name = f'{this_conf.name}-{int(conf_idx):02d}.sdf'
+                    this_conf.to_file(os.path.join(output_directory, out_file_name), file_format='sdf')
 
     #for (group_id, mol_idx), e in error_mols:
 


### PR DESCRIPTION
## Description
This PR wraps the conformer generation function with a process pool to help speed up the step. By default, the pool will use all available processors but I have also exposed the argument to the CLI.

The time taken to generate conformers for the ~200 jacs set of ligands is reduced from ~6mins to 30s.

## Questions
- [ ] are there any drawbacks to allowing this?

## Status
- [ ] Ready to go