### PR TITLE
Update coverage report

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 OpenFF Benchmark
 ==============================
 [//]: # (Badges)
-[![Travis Build Status](https://travis-ci.com/openforcefield/openff-benchmark.svg?branch=master)](https://travis-ci.com/openforcefield/openff-benchmark)
+![CI](https://github.com/openforcefield/openff-benchmark/workflows/CI/badge.svg)
 [![codecov](https://codecov.io/gh/openforcefield/openff-benchmark/branch/master/graph/badge.svg)](https://codecov.io/gh/openforcefield/openff-benchmark/branch/master)
+![Make single-file installers](https://github.com/openforcefield/openff-benchmark/workflows/Make%20single-file%20installers/badge.svg)
+![Pure-Python Package Build](https://github.com/openforcefield/openff-benchmark/workflows/Pure-Python%20Package%20Build/badge.svg)
+![Deployment - OpenFF Benchmark Prod Environments](https://github.com/openforcefield/openff-benchmark/workflows/Deployment%20-%20OpenFF%20Benchmark%20Prod%20Environments/badge.svg)
 
 Comparison benchmarks between public force fields and quantum chemical methods.
 

--- a/openff/benchmark/cli.py
+++ b/openff/benchmark/cli.py
@@ -25,9 +25,9 @@ if oetk_loaded:
     GLOBAL_TOOLKIT_REGISTRY.deregister_toolkit(OpenEyeToolkitWrapper)
 
 
-logging.basicConfig(filename=f'{sys.argv[2]}.log',
-                    level=logging.DEBUG
-                    )
+# logging.basicConfig(filename=f'{sys.argv[2]}.log',
+#                     level=logging.DEBUG
+#                     )
 
 
 @click.group()
@@ -419,10 +419,10 @@ def validate(input_3d_molecules, output_directory, group_name, delete_existing, 
     and a correspondingly-named txt file containing more details about the error.
     """
     from openforcefield.topology import Molecule
-    from .utils.validate_and_assign_ids import validate_and_assign
+    from openff.benchmark.utils.validate_and_assign_ids import validate_and_assign
+    from openff.benchmark.utils.utils import prepare_folders
     import glob
     import os
-    import shutil
     from tqdm import tqdm
     import copy
     import csv
@@ -432,28 +432,7 @@ def validate(input_3d_molecules, output_directory, group_name, delete_existing, 
     existing_name_assignments = []
 
     # Prepare required directories, ensuring that input flags (`delete_existing` and `add`) are sane
-    error_dir = os.path.join(output_directory, 'error_mols')
-    if delete_existing and add:
-        raise Exception("Can not specify BOTH --delete-existing AND --add flags")
-    # Delete pre-existing output mols if requested
-    elif delete_existing and not(add):
-        if os.path.exists(output_directory):
-            shutil.rmtree(output_directory)
-        os.makedirs(output_directory)
-        # Create error directory
-        error_dir = os.path.join(output_directory, 'error_mols')
-        os.makedirs(error_dir)
-    elif not(delete_existing) and add:
-        if not os.path.exists(output_directory):
-            raise Exception(f'--add flag was specified but directory {output_directory} not found')
-    # If ADD is FALSE, make new output dir
-    elif not(delete_existing) and not(add):
-        if os.path.exists(output_directory):
-            raise Exception(f'Output directory {output_directory} already exists. '
-                            f'Specify `--delete-existing` to remove.')
-        os.makedirs(output_directory)
-        # Create error directory
-        os.makedirs(error_dir)
+    error_dir = prepare_folders(output_directory=output_directory, delete_existing=delete_existing, add=add)
 
     input_mols = []
     error_mols = []
@@ -656,7 +635,7 @@ def generate_conformers(input_directory, output_directory, delete_existing):
 
 @preprocess.command()
 @click.argument("input_directory")
-@click.argument("forcefield_name")
+@click.option("-ff", "--forcefield_name", default="openff_unconstrained-1.3.0.offxml")
 @click.option("-o", "--output_directory",
               default="3-coverage_report",
               help="The directory for output files.")
@@ -669,37 +648,48 @@ def coverage_report(input_directory, forcefield_name, output_directory, processo
     Generate a coverage report for the set of validated input molecules.
     """
     from openff.benchmark.utils.coverage_report import generate_coverage_report
+    from openforcefield.topology import Molecule
+    from openff.benchmark.utils.utils import prepare_folders
     import json
+    import glob
     import os
     import shutil
 
-    try:
-        os.makedirs(output_directory)
-    except OSError:
-        if delete_existing:
-            shutil.rmtree(output_directory)
-            os.makedirs(os.path.join(output_directory, "error_mols"))
-        else:
-            raise Exception(f'Output directory {output_directory} already exists. '
-                             'Specify `delete_existing=True` to remove.')
+    error_dir = prepare_folders(output_directory=output_directory, delete_existing=delete_existing, add=False)
+    # Search for the 00th conformer so we dont double-count any moleucles
+    input_files = glob.glob(os.path.join(input_directory, "*00.sdf"))
+    # now load each molecule they should already be unique
+    molecules = [Molecule.from_file(mol_file, file_format="sdf", allow_undefined_stereo=True) for mol_file in input_files]
 
-    report, success_mols, error_mols = generate_coverage_report(input_molecules=input_directory,
+    report, success_mols, error_mols = generate_coverage_report(input_molecules=molecules,
                                       forcefield_name=forcefield_name,
                                       processors=processors,
                                       #output_directory=output_directory
                                       )
-    # Write successfully processed mols
+
+    # Copy successfully processed mols and all conformers to the new folder
     for success_mol in success_mols:
-        success_mol.to_file(os.path.join(output_directory, success_mol.name + ".sdf"), "sdf")
-    # Write errored mols
+        common_id = f"{success_mol.properties['group_name']}-{success_mol.properties['molecule_index']}"
+        # get all conformer files
+        conformer_files = glob.glob(os.path.join(input_directory, f"{common_id}*"))
+        for file in conformer_files:
+            shutil.copy(file, output_directory)
+    # Copy all conformers of an error mol to the error dir
     for error_mol, e in error_mols:
-        error_mol.to_file(os.path.join(output_directory, "error_mols", error_mol.name + ".sdf"), "sdf")
-        with open(os.path.join(output_directory, "error_mols", error_mol.name + ".txt"), 'w') as of:
-            of.write(e)
+        with open(os.path.join(error_dir, error_mol.name + ".txt"), 'w') as of:
+            of.write(f'source: {error_mol.name}\n')
+            of.write(f'error text: {e}\n')
+        # now get all conformers and move them
+        common_id = f"{error_mol.properties['group_name']}-{error_mol.properties['molecule_index']}"
+        conformer_files = glob.glob(os.path.join(input_directory, f"{common_id}*"))
+        for file in conformer_files:
+            shutil.copy(file, error_dir)
+
     # Write coverage report
     data = json.dumps(report, indent=2)
     with open(os.path.join(output_directory, "coverage_report.json"), "w") as reporter:
         reporter.write(data)
+        # TODO do we want the list of errors in the coverage report as well?
     
 
 if __name__ == "__main__":

--- a/openff/benchmark/cli.py
+++ b/openff/benchmark/cli.py
@@ -25,9 +25,9 @@ if oetk_loaded:
     GLOBAL_TOOLKIT_REGISTRY.deregister_toolkit(OpenEyeToolkitWrapper)
 
 
-# logging.basicConfig(filename=f'{sys.argv[2]}.log',
-#                     level=logging.DEBUG
-#                     )
+logging.basicConfig(filename=f'{sys.argv[2]}.log',
+                    level=logging.DEBUG
+                    )
 
 
 @click.group()

--- a/openff/benchmark/tests/test_coverage_report.py
+++ b/openff/benchmark/tests/test_coverage_report.py
@@ -253,5 +253,5 @@ def test_cli_add_molecules_error(tmpdir):
         assert new_report.pop("total_unique_molecules") > old_report.pop("total_unique_molecules")
         assert new_report.pop("passed_unique_molecules") == old_report.pop("passed_unique_molecules")
         assert new_report.pop("forcefield_name") == old_report.pop("forcefield_name")
-        # now we only have parameter counts left, make sure they have changed
+        # now we only have parameter counts left, make sure they have not changed
         assert new_report == old_report

--- a/openff/benchmark/tests/test_coverage_report.py
+++ b/openff/benchmark/tests/test_coverage_report.py
@@ -196,8 +196,8 @@ def test_cli_adding_molecules(tmpdir):
         with open(os.path.join(test_dir, "coverage_report.json")) as report:
             new_report = json.load(report)
 
-        assert new_report.pop("total_unique_molecules") > old_report.pop("total_unique_molecules")
-        assert new_report.pop("passed_unique_molecules") > old_report.pop("passed_unique_molecules")
+        assert new_report.pop("total_unique_molecules") == old_report.pop("total_unique_molecules") + 1
+        assert new_report.pop("passed_unique_molecules") == old_report.pop("passed_unique_molecules") + 1
         assert new_report.pop("forcefield_name") == old_report.pop("forcefield_name")
         # now we only have parameter counts left, make sure they have changed
         assert new_report != old_report

--- a/openff/benchmark/tests/test_coverage_report.py
+++ b/openff/benchmark/tests/test_coverage_report.py
@@ -175,10 +175,10 @@ def test_cli_adding_molecules(tmpdir):
             old_report = json.load(report)
 
         # now add a new molecule to dir
-        ehtane = Molecule.from_file(get_data_file_path("ethane.sdf"))
-        ehtane.properties["group_name"] = "BBB"
-        ehtane.properties["molecule_index"] = "99999"
-        ehtane.to_file(os.path.join(input_dir, "BBB-99999-00.sdf"), "sdf")
+        ethane = Molecule.from_file(get_data_file_path("ethane.sdf"))
+        ethane.properties["group_name"] = "BBB"
+        ethane.properties["molecule_index"] = "99999"
+        ethane.to_file(os.path.join(input_dir, "BBB-99999-00.sdf"), "sdf")
 
         # run again with add
         response = runner.invoke(cli, ["preprocess", "coverage-report",

--- a/openff/benchmark/tests/test_coverage_report.py
+++ b/openff/benchmark/tests/test_coverage_report.py
@@ -1,12 +1,19 @@
 from openff.benchmark.utils.coverage_report import generate_coverage_report
 from openff.benchmark.utils.utils import get_data_file_path
+from openff.benchmark.cli import cli
+from openforcefield.topology import Molecule
+import json
+import glob
+import os
 import pytest
+from click.testing import CliRunner
+runner = CliRunner()
 
 # Test single file
 @pytest.mark.parametrize('n_procs', [1,2])
 def test_single_file(n_procs):
-    in_file = get_data_file_path('1-validate_and_assign_graphs_and_confs/BBB-00000-00.sdf')
-    coverage, success_mols, error_mols = generate_coverage_report(input_molecules=in_file,
+    molecules = Molecule.from_file(get_data_file_path('1-validate_and_assign_graphs_and_confs/BBB-00000-00.sdf'), "sdf" )
+    coverage, success_mols, error_mols = generate_coverage_report(input_molecules=molecules,
                                                                   forcefield_name='openff_unconstrained-1.3.0.offxml',
                                                                   processors=n_procs)
     assert len(success_mols) == 1, error_mols[0][1]
@@ -15,31 +22,30 @@ def test_single_file(n_procs):
 # Test multiple files
 @pytest.mark.parametrize('n_procs', [1,2])
 def test_multiple_files(n_procs):
-    in_files = [get_data_file_path('1-validate_and_assign_graphs_and_confs/BBB-00000-00.sdf'),
-               get_data_file_path('1-validate_and_assign_graphs_and_confs/BBB-00001-00.sdf')]
-    coverage, success_mols, error_mols = generate_coverage_report(input_molecules=in_files,
+    molecules = [Molecule.from_file(get_data_file_path('1-validate_and_assign_graphs_and_confs/BBB-00000-00.sdf'), "sdf"),
+               Molecule.from_file(get_data_file_path('1-validate_and_assign_graphs_and_confs/BBB-00001-00.sdf'), "sdf")]
+    coverage, success_mols, error_mols = generate_coverage_report(input_molecules=molecules,
                                                                   forcefield_name='openff_unconstrained-1.3.0.offxml',
                                                                   processors=n_procs)
     assert len(success_mols) == 2
     assert len(error_mols) == 0
+    assert coverage["passed_unique_molecules"] == 2
+    assert coverage["total_unique_molecules"] == 2
     #raise Exception(error_mols)
-# Test not double counting if multiple conformers in the same directory
-def test_input_directory():
-    in_files = get_data_file_path('1-validate_and_assign_graphs_and_confs/')
-    coverage, success_mols, error_mols = generate_coverage_report(input_molecules=in_files,
-                                                                  forcefield_name='openff_unconstrained-1.3.0.offxml')
-    assert len(success_mols) == 4
-    assert len(error_mols) == 0
+
+
 
 # Test catching uncovered params
 @pytest.mark.parametrize('n_procs',[1,2])
 def test_error_missing_valence_param(n_procs):
-    in_file = get_data_file_path('missing_valence_params.sdf')
-    coverage, success_mols, error_mols = generate_coverage_report(input_molecules=in_file,
+    molecules = Molecule.from_file(get_data_file_path('missing_valence_params.sdf'), "sdf")
+    coverage, success_mols, error_mols = generate_coverage_report(input_molecules=molecules,
                                                                   forcefield_name='openff_unconstrained-1.3.0.offxml',
                                                                   processors=n_procs)
     assert len(success_mols) == 0
     assert len(error_mols) == 1
+    assert coverage["passed_unique_molecules"] == 0
+    assert coverage["total_unique_molecules"] == 1
     assert "BondHandler was not able to find parameters" in str(error_mols[0][1])
 
 # Test for a molecule covered by OpenFF but that causes antechamber to fail
@@ -48,9 +54,68 @@ def test_error_missing_valence_param(n_procs):
 # Search "deregister_parameter_handler" in coverage_report.py
 @pytest.mark.skip
 def test_error_uncovered_antechamber_param():
-    in_file = get_data_file_path('sodium_carbide.sdf')
-    coverage, success_mols, error_mols = generate_coverage_report(input_molecules=in_file,
+    molecule = Molecule.from_file(get_data_file_path('sodium_carbide.sdf'), "sdf")
+    coverage, success_mols, error_mols = generate_coverage_report(input_molecules=molecule,
                                                                   forcefield_name='openff_unconstrained-1.3.0.offxml')
     assert len(success_mols) == 0
     assert len(error_mols) == 1
+    assert coverage["passed_unique_molecules"] == 0
+    assert coverage["total_unique_molecules"] == 1
     assert "Command '['antechamber'" in str(error_mols[0][1])
+
+
+def test_cli_move_all_confs(tmpdir):
+    """
+    Make sure that if a molecule passes all conformers are also moved.
+    """
+
+    with tmpdir.as_cwd():
+        test_dir = '3-coverage_report'
+        input_folder = get_data_file_path('1-validate_and_assign_graphs_and_confs')
+        # get the number of input molecules and conformers
+        n_input_moles = len(glob.glob(os.path.join(input_folder, "*.sdf")))
+        response = runner.invoke(cli, ["preprocess", "coverage-report",
+                                       "-p", 1,
+                                       "-o", test_dir,
+                                       input_folder],
+                                 catch_exceptions=False)
+        n_out_mols = len(glob.glob(os.path.join(test_dir, "*.sdf")))
+        # assuming no molecules fail
+        assert n_input_moles == n_out_mols
+        n_error_mols = len(glob.glob(os.path.join(test_dir, "error_mols", "*.sdf")))
+        assert n_error_mols == 0
+        # load the coverage report and make sure the unique mols is correct
+        with open(os.path.join(test_dir, "coverage_report.json"), "r") as data:
+            report = json.load(data)
+
+        assert report["passed_unique_molecules"] == 5
+        assert report["total_unique_molecules"] == 5
+
+
+def test_cli_error_mol(tmpdir):
+    """Make sure that molecules that fail are correctly put in error mols folder."""
+
+    with tmpdir.as_cwd():
+        test_dir = '3-coverage_report'
+        input_folder = "2-generate_conformers"
+        os.mkdir(input_folder)
+        mol = Molecule.from_file(get_data_file_path('missing_valence_params.sdf'), "sdf", allow_undefined_stereo=True)
+        mol.properties["group_name"] = "OFF"
+        mol.properties["molecule_index"] = "00000"
+        mol.to_file(os.path.join(input_folder, "OFF-00000-00.sdf"), "sdf")
+        response = runner.invoke(cli, ["preprocess", "coverage-report",
+                                       "-p", 1,
+                                       "-o", test_dir,
+                                       input_folder],
+                                 catch_exceptions=False)
+
+        n_out_mols = len(glob.glob(os.path.join(test_dir, "*.sdf")))
+        assert n_out_mols == 0
+        n_error_mols = len(glob.glob(os.path.join(test_dir, "error_mols", "*.sdf")))
+        assert n_error_mols == 1
+        # load the coverage report and make sure the unique mols is correct
+        with open(os.path.join(test_dir, "coverage_report.json"), "r") as data:
+            report = json.load(data)
+
+        assert report["passed_unique_molecules"] == 0
+        assert report["total_unique_molecules"] == 1

--- a/openff/benchmark/utils/coverage_report.py
+++ b/openff/benchmark/utils/coverage_report.py
@@ -110,6 +110,11 @@ def generate_coverage_report(input_molecules: List[Molecule],
             else:
                 error_mols.append((molecule, e))
 
+    # Sort the keys of the coverage dict, so that it doesn't show which parameters were found first
+    for parameter_type in coverage.keys():
+        sorted_sub_dict = dict(sorted(coverage[parameter_type].items()))
+        coverage[parameter_type] = sorted_sub_dict
+
     # record how many molecules we processed
     coverage["passed_unique_molecules"] = len(success_mols)
     coverage["total_unique_molecules"] = len(success_mols) + len(error_mols)

--- a/openff/benchmark/utils/coverage_report.py
+++ b/openff/benchmark/utils/coverage_report.py
@@ -26,6 +26,18 @@ for tkw in GLOBAL_TOOLKIT_REGISTRY.registered_toolkits:
 if oetk_loaded:
     GLOBAL_TOOLKIT_REGISTRY.deregister_toolkit(OpenEyeToolkitWrapper)
 
+def _update_coverage(main_report, single_report):
+    """
+    Take the single molecule report and update the master coverage dict
+    """
+    for param_type in main_report.keys():
+        for param_id, no in single_report[param_type].items():
+            if param_id not in main_report[param_type]:
+                # set the param number if new
+                main_report[param_type][param_id] = no
+            else:
+                # add onto the current parameter count
+                main_report[param_type][param_id] += no
 
 def generate_coverage_report(input_molecules: List[Molecule],
                              forcefield_name: str,
@@ -49,19 +61,7 @@ def generate_coverage_report(input_molecules: List[Molecule],
     if isinstance(input_molecules, Molecule):
         input_molecules = [input_molecules, ]
     coverage = {"Angles": {}, "Bonds": {}, "ProperTorsions": {}, "ImproperTorsions": {}, "vdW": {}}
-    # a func to update the coverage dict
-    def update_coverage(single_report):
-        """
-        Take the single molecule report and update the master coverage dict
-        """
-        for param_type in coverage.keys():
-            for param_id, no in single_report[param_type].items():
-                if param_id not in coverage[param_type]:
-                    # set the param number if new
-                    coverage[param_type][param_id] = no
-                else:
-                    # add onto the current parameter count
-                    coverage[param_type][param_id] += no
+
 
     # make the forcefield
     ff = ForceField(forcefield_name)
@@ -88,7 +88,7 @@ def generate_coverage_report(input_molecules: List[Molecule],
                 report, e = work.get()
                 molecule = report["molecule"]
                 if e is None:
-                    update_coverage(report)
+                    _update_coverage(coverage, report)
                     success_mols.append(molecule)
                 #except Exception as e:
                 else:
@@ -104,7 +104,7 @@ def generate_coverage_report(input_molecules: List[Molecule],
             # update the master coverage dict
             mol: Molecule = report["molecule"]
             if e is None:
-                update_coverage(report)
+                _update_coverage(coverage, report)
                 success_mols.append(mol)
             #except Exception as e:
             else:

--- a/openff/benchmark/utils/coverage_report.py
+++ b/openff/benchmark/utils/coverage_report.py
@@ -27,11 +27,9 @@ if oetk_loaded:
     GLOBAL_TOOLKIT_REGISTRY.deregister_toolkit(OpenEyeToolkitWrapper)
 
 
-
-def generate_coverage_report(input_molecules: Union[List[str], str],
-                             forcefield_name,
-                             processors: Optional[int] = None,
-                            ) -> Dict[str, Dict[str, int]]:
+def generate_coverage_report(input_molecules: List[Molecule],
+                             forcefield_name: str,
+                             processors: Optional[int] = None):
     """
     For the given set of molecules produce a coverage report of the smirks parameters used in typing the molecule.
     Also try and produce charges for the molecules as some may have missing bccs.
@@ -41,8 +39,6 @@ def generate_coverage_report(input_molecules: Union[List[str], str],
     input_molecules: The List of 3d sdf files to run the coverage on or the name of the directory containing the files.
     forcefield_name: The name of the openFF forcefield to run the coverage for.
     processors: The number of processors we can use to build the coverage report
-    output_directory: The directory the files will be writen too if they pass the coverage step
-    delete_existing: If any files currently exist remove them and run again
 
     Returns
     -------
@@ -50,20 +46,8 @@ def generate_coverage_report(input_molecules: Union[List[str], str],
     success_mols: A list of openforcefield.topology.Molecule objects that were successful in this step
     error_mols: A list of tuples (Molecule, Exception) of molecules that failed this step
     """
-
-    if isinstance(input_molecules, list):
-        input_files = input_molecules
-    else:
-        # check if its a dir then look for sdfs
-        if os.path.isdir(input_molecules):
-            # Search for the 00th conformer so we dont double-count any moleucles
-            input_files = glob.glob(os.path.join(input_molecules, "*00.sdf"))
-        else:
-            input_files = [input_molecules, ]
-
-    # now load each molecule they should already be unique
-    molecules = [Molecule.from_file(mol_file, file_format="sdf", allow_undefined_stereo=True) for mol_file in input_files]
-
+    if isinstance(input_molecules, Molecule):
+        input_molecules = [input_molecules, ]
     coverage = {"Angles": {}, "Bonds": {}, "ProperTorsions": {}, "ImproperTorsions": {}, "vdW": {}}
     # a func to update the coverage dict
     def update_coverage(single_report):
@@ -76,7 +60,7 @@ def generate_coverage_report(input_molecules: Union[List[str], str],
                     # set the param number if new
                     coverage[param_type][param_id] = no
                 else:
-                    # add onto the current parmeter count
+                    # add onto the current parameter count
                     coverage[param_type][param_id] += no
 
     # make the forcefield
@@ -94,7 +78,7 @@ def generate_coverage_report(input_molecules: Union[List[str], str],
 
         with Pool(processes=processors) as pool:
             # generate the work list
-            work_list = [pool.apply_async(single_molecule_coverage, (molecule, ff)) for molecule in molecules]
+            work_list = [pool.apply_async(single_molecule_coverage, (molecule, ff)) for molecule in input_molecules]
             for work in tqdm.tqdm(
                     work_list,
                     total=len(work_list),
@@ -111,8 +95,8 @@ def generate_coverage_report(input_molecules: Union[List[str], str],
                     error_mols.append((molecule, e))
 
     else:
-        for molecule in tqdm.tqdm(molecules,
-                                  total=len(molecules),
+        for molecule in tqdm.tqdm(input_molecules,
+                                  total=len(input_molecules),
                                   ncols=80,
                                   desc="{:30s}".format("Generating Coverage")):
             #try:
@@ -125,6 +109,11 @@ def generate_coverage_report(input_molecules: Union[List[str], str],
             #except Exception as e:
             else:
                 error_mols.append((molecule, e))
+
+    # record how many molecules we processed
+    coverage["passed_unique_molecules"] = len(success_mols)
+    coverage["total_unique_molecules"] = len(success_mols) + len(error_mols)
+    coverage["forcefield_name"] = forcefield_name
 
     return coverage, success_mols, error_mols
 

--- a/openff/benchmark/utils/utils.py
+++ b/openff/benchmark/utils/utils.py
@@ -1,5 +1,5 @@
-import os
 import contextlib
+
 
 def get_data_file_path(relative_path):
     """
@@ -27,6 +27,7 @@ def get_data_file_path(relative_path):
 
     return fn
 
+
 @contextlib.contextmanager
 def temporary_cd(dir_path):
     """Context to temporary change the working directory.
@@ -48,3 +49,45 @@ def temporary_cd(dir_path):
         yield
     finally:
         os.chdir(prev_dir)
+
+
+def prepare_folders(output_directory: str, delete_existing: bool, add: bool) -> str:
+    """
+    A general folder prep function to help with the preprocess steps, this will handle general file prep and delete_existing and add conflicts.
+    Parameters
+    ----------
+    output_directory: The name of the output directory that should be made.
+    delete_existing: If the existing output directory should be overwritten
+    add: If the user is trying to add molecules to an existing output folder.
+
+    Returns
+    -------
+    error_dir: The name of the error directory that has been made/found.
+    """
+    import os
+    import shutil
+
+    error_dir = os.path.join(output_directory, 'error_mols')
+    if delete_existing and add:
+        raise Exception("Can not specify BOTH --delete-existing AND --add flags")
+    # Delete pre-existing output mols if requested
+    elif delete_existing and not (add):
+        if os.path.exists(output_directory):
+            shutil.rmtree(output_directory)
+        os.makedirs(output_directory)
+        # Create error directory
+        error_dir = os.path.join(output_directory, 'error_mols')
+        os.makedirs(error_dir)
+    elif not (delete_existing) and add:
+        if not os.path.exists(output_directory):
+            raise Exception(f'--add flag was specified but directory {output_directory} not found')
+    # If ADD is FALSE, make new output dir
+    elif not (delete_existing) and not (add):
+        if os.path.exists(output_directory):
+            raise Exception(f'Output directory {output_directory} already exists. '
+                            f'Specify `--delete-existing` to remove.')
+        os.makedirs(output_directory)
+        # Create error directory
+        os.makedirs(error_dir)
+
+    return error_dir


### PR DESCRIPTION
## Description
Fixes #46 and fixes #31 , the coverage reporter will now only test on one conformer per unique molecule. If the molecule passes all conformers are moved to the output folder if the molecule fails all conformers are moved the error_mols folder in the output.
The coverage reporter now also records the total number of molecules screened along with the number of molecules that pass so we can work out a failure rate. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [X] Expand the coverage report to move all conformers of a molecule that passes to the next folder
  - [x] Add the ability to add new molecules from a past step 
  - [x] Fixes #51 

## Questions
- [x] Do we want to include the error messages in the coverage report? Can we do this without exposing sensitive data?

## Status
- [ ] Ready to go