### PR TITLE
Allow undefined stereochemistry on molecule export

### DIFF
--- a/openff/benchmark/geometry_optimizations/compute.py
+++ b/openff/benchmark/geometry_optimizations/compute.py
@@ -90,7 +90,7 @@ class OptimizationExecutor:
         except toolkits.ToolkitUnavailableException:
             pass
     
-        return Molecule.from_qcschema(record)
+        return Molecule.from_qcschema(qca_record=record, allow_undefined_stereo=True)
     
     def export_molecule_data(self, fractal_uri, output_directory, dataset_name,
                              delete_existing=False, keep_existing=True):


### PR DESCRIPTION
## Description
Fixes #58 by allowing undefined stereochemistry during molecule export.

## Questions
- [ ] Is this safe to do or should we skip these records?

## Status
- [ ] Ready to go