### PR TITLE
Prod envs now use openforcefield 0.8.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Cache conda
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       env:
         # Increase this value to reset cache if etc/example-environment.yml has not changed
         CACHE_NUMBER: 0

--- a/devtools/prod-envs/openff-benchmark-analysis.yaml
+++ b/devtools/prod-envs/openff-benchmark-analysis.yaml
@@ -18,7 +18,7 @@ dependencies:
   - alembic
   - psycopg2 >=2.7
   - postgresql
-  - sqlalchemy >=1.3
+  - sqlalchemy =1.3
 
   # QCPortal dependencies
   - double-conversion >=3.0.0

--- a/devtools/prod-envs/openff-benchmark-analysis.yaml
+++ b/devtools/prod-envs/openff-benchmark-analysis.yaml
@@ -29,7 +29,7 @@ dependencies:
   - tqdm
 
   # MM calculations
-  - openforcefield =0.8.4rc1
+  - openforcefield =0.8.4
   - rdkit =2020.09
   - openforcefields =1.3.0
   - openmm =7.4.2

--- a/devtools/prod-envs/openff-benchmark-analysis.yaml
+++ b/devtools/prod-envs/openff-benchmark-analysis.yaml
@@ -18,7 +18,7 @@ dependencies:
   - alembic
   - psycopg2 >=2.7
   - postgresql
-  - sqlalchemy =1.3
+  - sqlalchemy >=1.3,<1.4
 
   # QCPortal dependencies
   - double-conversion >=3.0.0

--- a/devtools/prod-envs/openff-benchmark-optimization.yaml
+++ b/devtools/prod-envs/openff-benchmark-optimization.yaml
@@ -37,7 +37,7 @@ dependencies:
   - gcp
     
   # MM calculations
-  - openforcefield =0.8.4rc1
+  - openforcefield =0.8.4
   - rdkit =2020.09
   - openforcefields =1.3.0
   - openmm =7.4.2

--- a/devtools/prod-envs/openff-benchmark-optimization.yaml
+++ b/devtools/prod-envs/openff-benchmark-optimization.yaml
@@ -20,7 +20,7 @@ dependencies:
   - alembic
   - psycopg2 >=2.7
   - postgresql
-  - sqlalchemy =1.3
+  - sqlalchemy >=1.3,<1.4
 
   # QCPortal dependencies
   - double-conversion >=3.0.0

--- a/devtools/prod-envs/openff-benchmark-optimization.yaml
+++ b/devtools/prod-envs/openff-benchmark-optimization.yaml
@@ -20,7 +20,7 @@ dependencies:
   - alembic
   - psycopg2 >=2.7
   - postgresql
-  - sqlalchemy >=1.3
+  - sqlalchemy =1.3
 
   # QCPortal dependencies
   - double-conversion >=3.0.0

--- a/openff/benchmark/geometry_optimizations/compute.py
+++ b/openff/benchmark/geometry_optimizations/compute.py
@@ -701,8 +701,7 @@ class OptimizationExecutor:
         # TODO: bug report in openff where `atom_map` is a string
         if isinstance(mol.properties.get('atom_map'), str):
             mol.properties['atom_map'] = ast.literal_eval(mol.properties['atom_map'])
-    
-        attributes = factory.create_cmiles_metadata(mol)
+
         method = compute_spec['method']
         basis = compute_spec['basis']
         program = compute_spec['program']
@@ -741,7 +740,7 @@ class OptimizationExecutor:
                       ]
                     },
                 },
-                initial_molecule=mol.to_qcschema(extras=attributes)
+                initial_molecule=mol.to_qcschema()
             )
 
         return input_data.dict()

--- a/openff/benchmark/geometry_optimizations/compute.py
+++ b/openff/benchmark/geometry_optimizations/compute.py
@@ -702,7 +702,7 @@ class OptimizationExecutor:
         if isinstance(mol.properties.get('atom_map'), str):
             mol.properties['atom_map'] = ast.literal_eval(mol.properties['atom_map'])
 
-        # This block will fail for OFF Toolkit 0.8.4, but succeed for 0.8.3rc1
+        # This block will fail for OFF Toolkit 0.8.4, but succeed for 0.8.4rc1
         try:
             attributes = factory.create_cmiles_metadata(mol)
             qcmol = mol.to_qcschema(extras=attributes)

--- a/openff/benchmark/geometry_optimizations/compute.py
+++ b/openff/benchmark/geometry_optimizations/compute.py
@@ -702,6 +702,14 @@ class OptimizationExecutor:
         if isinstance(mol.properties.get('atom_map'), str):
             mol.properties['atom_map'] = ast.literal_eval(mol.properties['atom_map'])
 
+        # This block will fail for OFF Toolkit 0.8.4, but succeed for 0.8.3rc1
+        try:
+            attributes = factory.create_cmiles_metadata(mol)
+            qcmol = mol.to_qcschema(extras=attributes)
+        # In OFFTK 0.8.4, the CMILES field is automatically populated by this method
+        except:
+            qcmol = mol.to_qcschema()
+
         method = compute_spec['method']
         basis = compute_spec['basis']
         program = compute_spec['program']
@@ -740,8 +748,7 @@ class OptimizationExecutor:
                       ]
                     },
                 },
-                initial_molecule=mol.to_qcschema()
-            )
+                initial_molecule=qcmol)
 
         return input_data.dict()
 

--- a/openff/benchmark/geometry_optimizations/compute.py
+++ b/openff/benchmark/geometry_optimizations/compute.py
@@ -90,7 +90,15 @@ class OptimizationExecutor:
         except toolkits.ToolkitUnavailableException:
             pass
     
-        return Molecule.from_qcschema(record)
+        offmol = Molecule.from_qcschema(record)
+
+        # we really don't want the molecule populated with a conformer
+        # we're actually feeding this function an entry in our usage below,
+        # so it won't get one, but to be safe we set it to None so we can put
+        # just our final molecule there
+        offmol._conformers = None
+
+        return offmol
     
     def export_molecule_data(self, fractal_uri, output_directory, dataset_name,
                              delete_existing=False, keep_existing=True):

--- a/openff/benchmark/tests/test_geometry_optimizations.py
+++ b/openff/benchmark/tests/test_geometry_optimizations.py
@@ -141,6 +141,8 @@ def test_cli_optimize_export_qm(fractal_compute_server, tmpdir, ethane_preproces
                                        '--dataset-name', '"Test Dataset - QM"',
                                        '-o', outdir])
 
+        if response.exception:
+            print(response.exception)
         assert response.exit_code == 0
         assert "exporting COMPLETE" in response.output
 
@@ -166,6 +168,8 @@ def test_cli_optimize_export_mm(fractal_compute_server, tmpdir, ethane_qm_optimi
                                        '--dataset-name', '"Test Dataset - MM"',
                                        '-o', outdir])
 
+        if response.exception:
+            print(response.exception)
         assert response.exit_code == 0
         assert "exporting COMPLETE" in response.output
 


### PR DESCRIPTION
## Description
Version bump for the openforcefield toolkit 0.8.4rc1 -> 0.8.4.

Shouldn't be much different than 0.8.4rc1, so shouldn't be dramatic.

## Status
- [x] Ready to go