### PR TITLE
Coverage fix

### DIFF
--- a/openff/benchmark/cli.py
+++ b/openff/benchmark/cli.py
@@ -853,9 +853,9 @@ def coverage_report(input_directory, forcefield_name, output_directory, processo
 
     # Copy successfully processed mols and all conformers to the new folder
     for success_mol in success_mols:
-        common_id = f"{success_mol.properties['group_name']}-{success_mol.properties['molecule_index']}"
+        common_id = f"{success_mol.properties['group_name']}-{str(success_mol.properties['molecule_index']).zfill(5)}"
         # get all conformer files
-        conformer_files = glob.glob(os.path.join(input_directory, f"{common_id}*"))
+        conformer_files = glob.glob(os.path.join(input_directory, f"{common_id}-*.sdf"))
         for file in conformer_files:
             shutil.copy(file, output_directory)
     # Copy all conformers of an error mol to the error dir
@@ -864,8 +864,9 @@ def coverage_report(input_directory, forcefield_name, output_directory, processo
             of.write(f'source: {error_mol.name}\n')
             of.write(f'error text: {e}\n')
         # now get all conformers and move them
-        common_id = f"{error_mol.properties['group_name']}-{error_mol.properties['molecule_index']}"
-        conformer_files = glob.glob(os.path.join(input_directory, f"{common_id}*"))
+        mol_index = str(error_mol.properties["molecule_index"]).zfill(5)
+        common_id = f"{error_mol.properties['group_name']}-{mol_index}"
+        conformer_files = glob.glob(os.path.join(input_directory, f"{common_id}-*.sdf"))
         for file in conformer_files:
             shutil.copy(file, error_dir)
 

--- a/openff/benchmark/tests/test_coverage_report.py
+++ b/openff/benchmark/tests/test_coverage_report.py
@@ -102,8 +102,8 @@ def test_cli_error_mol(tmpdir):
         os.mkdir(input_folder)
         mol = Molecule.from_file(get_data_file_path('missing_valence_params.sdf'), "sdf", allow_undefined_stereo=True)
         mol.properties["group_name"] = "OFF"
-        mol.properties["molecule_index"] = "00000"
-        mol.to_file(os.path.join(input_folder, "OFF-00000-00.sdf"), "sdf")
+        mol.properties["molecule_index"] = "00001"
+        mol.to_file(os.path.join(input_folder, "OFF-00001-00.sdf"), "sdf")
         response = runner.invoke(cli, ["preprocess", "coverage-report",
                                        "-p", 1,
                                        "-o", test_dir,

--- a/openff/benchmark/utils/coverage_report.py
+++ b/openff/benchmark/utils/coverage_report.py
@@ -67,9 +67,10 @@ def generate_coverage_report(input_molecules: List[Molecule],
     ff = ForceField(forcefield_name)
     # For speed, don't test charge assignment for now
     ff.deregister_parameter_handler('ToolkitAM1BCC')
-    ff.get_parameter_handler('ChargeIncrementModel',
-                             {'partial_charge_method':'formal_charge',
-                              'version':'0.3'})
+    ff.deregister_parameter_handler("Electrostatics")
+    # ff.get_parameter_handler('ChargeIncrementModel',
+    #                          {'partial_charge_method':'formal_charge',
+    #                           'version':'0.3'})
     # now run coverage on each molecule
     success_mols = []
     error_mols = []

--- a/openff/benchmark/utils/coverage_report.py
+++ b/openff/benchmark/utils/coverage_report.py
@@ -67,10 +67,10 @@ def generate_coverage_report(input_molecules: List[Molecule],
     ff = ForceField(forcefield_name)
     # For speed, don't test charge assignment for now
     ff.deregister_parameter_handler('ToolkitAM1BCC')
-    ff.deregister_parameter_handler("Electrostatics")
-    # ff.get_parameter_handler('ChargeIncrementModel',
-    #                          {'partial_charge_method':'formal_charge',
-    #                           'version':'0.3'})
+    # ff.deregister_parameter_handler("Electrostatics")
+    ff.get_parameter_handler('ChargeIncrementModel',
+                             {'partial_charge_method': 'formal_charge',
+                              'version': '0.3'})
     # now run coverage on each molecule
     success_mols = []
     error_mols = []


### PR DESCRIPTION
## Description
This PR fixes the coverage filter and stops failed molecules from getting past the step. This was caused by the use of the molecule index when doing a glob search which should have been padded using zfill. The test to catch this has been updated as well.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [X] Fix #67 

## Questions
- [ ] <s>I saw some strange coverage report fails related to missing charges when testing, so I have removed all electrostatic parameter handlers is there any danger to doing this? <s/>

## Status
- [x] Ready to go