### PR TITLE
Smarts filter

### DIFF
--- a/openff/benchmark/cli.py
+++ b/openff/benchmark/cli.py
@@ -911,11 +911,11 @@ def filter():
 @click.option("-s", "--smirks", multiple=True)
 @click.option("-p", "--processors",
               default=None,
-              type=click.INT, help="Number of parellel processes to use to generate coverage report")
+              type=click.INT, help="Number of parellel processes to use apply SMIRKS filter")
 def smirks(input_directory, output_directory, smirks, processors):
     """
-    Run a smirks filer which seperates the molecules, all molecules that pass the filter are put in the output directory.
-    Those that fail are put in the error mols directory in the output.
+    Filter out molecules that match specified smirks pattern(s). Molecules that do not match the filter are put in the output directory.
+    Those that do match the pattern are put in the error mols directory.
     """
     from openff.benchmark.utils.filters import smirks_filter
     from openforcefield.topology import Molecule

--- a/openff/benchmark/tests/test_filters.py
+++ b/openff/benchmark/tests/test_filters.py
@@ -10,7 +10,7 @@ runner = CliRunner()
 
 
 def test_single_smirks():
-    """Test filtering based on a single smikrs."""
+    """Test filtering based on a single smirks."""
     molecules = []
     for i in [0, 1, 2, 3, 5]:
         molecules.append(Molecule.from_file(get_data_file_path(f'1-validate_and_assign_graphs_and_confs/BBB-0000{i}-00.sdf'), "sdf" ))
@@ -26,7 +26,7 @@ def test_double_smirks():
     for i in [0, 1, 2, 3, 5]:
         molecules.append(
             Molecule.from_file(get_data_file_path(f'1-validate_and_assign_graphs_and_confs/BBB-0000{i}-00.sdf'), "sdf"))
-    # filter P should only be one molecule
+    # filter P should only be one molecule, and F should also be one molecule
     result = smirks_filter(input_molecules=molecules, filtered_smirks=["[P:1]", "[F:1]"], processors=1)
     assert result.n_filtered == 2
     assert result.n_molecules == 3

--- a/openff/benchmark/tests/test_filters.py
+++ b/openff/benchmark/tests/test_filters.py
@@ -1,0 +1,51 @@
+from openff.benchmark.utils.filters import smirks_filter
+from openff.benchmark.utils.utils import get_data_file_path
+from openff.benchmark.cli import cli
+from openforcefield.topology import Molecule
+import glob
+import os
+import pytest
+from click.testing import CliRunner
+runner = CliRunner()
+
+
+def test_single_smirks():
+    """Test filtering based on a single smikrs."""
+    molecules = []
+    for i in [0, 1, 2, 3, 5]:
+        molecules.append(Molecule.from_file(get_data_file_path(f'1-validate_and_assign_graphs_and_confs/BBB-0000{i}-00.sdf'), "sdf" ))
+    # filter P should only be one molecule
+    result = smirks_filter(input_molecules=molecules, filtered_smirks=["[P:1]"], processors=1)
+    assert result.n_filtered == 1
+    assert result.n_molecules == 4
+
+
+def test_double_smirks():
+    """Test filtering based on 2 different smirks patterns."""
+    molecules = []
+    for i in [0, 1, 2, 3, 5]:
+        molecules.append(
+            Molecule.from_file(get_data_file_path(f'1-validate_and_assign_graphs_and_confs/BBB-0000{i}-00.sdf'), "sdf"))
+    # filter P should only be one molecule
+    result = smirks_filter(input_molecules=molecules, filtered_smirks=["[P:1]", "[F:1]"], processors=1)
+    assert result.n_filtered == 2
+    assert result.n_molecules == 3
+
+
+def test_cli_move_molecules(tmpdir):
+    """Make sure that the cli can correctly move the molecules to the passed and fail directories."""
+    with tmpdir.as_cwd():
+        input_folder = get_data_file_path('1-validate_and_assign_graphs_and_confs')
+        n_input_moles = len(glob.glob(os.path.join(input_folder, "*.sdf")))
+        test_dir = '5-smirks_filter'
+        response = runner.invoke(cli, ["filter", "smirks",
+                                       input_folder,
+                                       test_dir,
+                                       "-p", 1,
+                                       "-s", "[P:1]"],
+                                 catch_exceptions=False)
+        n_out_mols = len(glob.glob(os.path.join(test_dir, "*.sdf")))
+        # this should only remove 1 molecule with 2 conformers
+        assert n_out_mols == n_input_moles - 2
+        n_error_mols = len(glob.glob(os.path.join(test_dir, "error_mols", "*.sdf")))
+        assert n_error_mols == 2

--- a/openff/benchmark/utils/filters.py
+++ b/openff/benchmark/utils/filters.py
@@ -8,12 +8,12 @@ if TYPE_CHECKING:
 
 def smirks_filter(input_molecules: List["Molecule"], filtered_smirks: List[str], processors: Optional[int] = None) -> "ComponentResult":
     """
-    Filter a list of openforcefield.topology.Molecules based on a list of unwated smirks patterns.
+    Filter a list of openforcefield.topology.Molecules based on a list of unwanted smirks patterns.
 
     Parameters
     ----------
     input_molecules: A list of molecules to be processed by the filter.
-    filtered_smirks: A list of smirks to be queried against the molecules:
+    filtered_smirks: A list of smirks to be queried against the molecules. Molecules matching any of these smirks will be filtered out.
     processors: The number of processors that should be used when filtering.
 
     Returns

--- a/openff/benchmark/utils/filters.py
+++ b/openff/benchmark/utils/filters.py
@@ -13,8 +13,8 @@ def smirks_filter(input_molecules: List["Molecule"], filtered_smirks: List[str],
     Parameters
     ----------
     input_molecules: A list of molecules to be processed by the filter.
-    smirks: A list of smirks to be queried agasint the molecules:
-    processors: The number of prcessors that should be used when filtering.
+    filtered_smirks: A list of smirks to be queried against the molecules:
+    processors: The number of processors that should be used when filtering.
 
     Returns
     -------

--- a/openff/benchmark/utils/filters.py
+++ b/openff/benchmark/utils/filters.py
@@ -1,0 +1,26 @@
+from openff.qcsubmit.workflow_components import SmartsFilter
+from typing import TYPE_CHECKING, List, Optional
+
+if TYPE_CHECKING:
+    from openforcefield.topology import Molecule
+    from openff.qcsubmit.datasets import ComponentResult
+
+
+def smirks_filter(input_molecules: List["Molecule"], filtered_smirks: List[str], processors: Optional[int] = None) -> "ComponentResult":
+    """
+    Filter a list of openforcefield.topology.Molecules based on a list of unwated smirks patterns.
+
+    Parameters
+    ----------
+    input_molecules: A list of molecules to be processed by the filter.
+    smirks: A list of smirks to be queried agasint the molecules:
+    processors: The number of prcessors that should be used when filtering.
+
+    Returns
+    -------
+        A component result object which contains a list of passed and failed molecules .
+    """
+
+    smarts_fil = SmartsFilter(filtered_substructures=filtered_smirks)
+    result = smarts_fil.apply(molecules=input_molecules, processors=processors, verbose=True)
+    return result


### PR DESCRIPTION
## Description
This PR adds a simple smarts filter using QCSubmit. Users are able to apply the filter at any stage in the workflow and must use smirks to make this work, multiple smirks can also be provided.

`openff-benchmark filter smirks <input_dir> <output_dir> -p 1 -s "[P:1]" -s "[I:1]"`

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [X] tests

## Questions
- [ ] Would we like to expose any other filters from qcsubmit like an element filter which might be easier when filtering by element than using the smirks filter?

## Status
- [ ] Ready to go