### PR TITLE
added intersection to draw.py, skipped QM-to-QM comparison on analysis.py

### DIFF
--- a/openff/benchmark/analysis/analysis.py
+++ b/openff/benchmark/analysis/analysis.py
@@ -207,6 +207,8 @@ def main(input_path, ref_method, output_directory="./results"):
 
     os.makedirs(output_directory, exist_ok=True)
     for m in tqdm(dataframes, desc='Processing data'):
+        if m == ref_method:
+            continue
         ref_to_ref_confs(dataframes[m], ref_confs)
         calc_rmsd(dataframes[ref_method], dataframes[m])
         calc_tfd(dataframes[ref_method], dataframes[m])

--- a/openff/benchmark/analysis/draw.py
+++ b/openff/benchmark/analysis/draw.py
@@ -524,8 +524,9 @@ def draw_density2d(
     colorbar_and_finish(size1, out_file)
 
 
-def plot_compare_ffs(results_dir, ref_method, output_directory):
+def plot_compare_ffs(results_dir, output_directory):
     global results
+    global method
     os.makedirs(output_directory, exist_ok=True)
     results = {}
     for path in results_dir:
@@ -544,7 +545,7 @@ def plot_compare_ffs(results_dir, ref_method, output_directory):
     for m, df in results.items():
         results[m].set_index('name', inplace=True)
 
-    index_intersect = results[ref_method].index
+    index_intersect = results[method].index
     for m in results:
         index_intersect = index_intersect.intersection(results[m].index)
     for m, df in results.items():
@@ -553,10 +554,10 @@ def plot_compare_ffs(results_dir, ref_method, output_directory):
             warnings.warn(f"Not all conformers of method {m} considered, because these are not available in other methods.")
 
 
-    plot_mol_minima(results, ref_method,  out_file=os.path.join(output_directory, 'minimaE.png'))
+    plot_mol_minima(results, method, out_file=os.path.join(output_directory, 'minimaE.png'))
     # we do not want to plot the ref_method in the following plots
     # remove it
-    results.pop(ref_method)
+    #results.pop(ref_method)
     plot_violin_signed(results, out_file=os.path.join(output_directory, 'violin.svg'))
 
 
@@ -883,7 +884,7 @@ def plot_mol_rmses(mol_name, rmses, xticklabels, eff_nconfs, ref_nconfs, what_fo
     plt.close(plt.gcf())
 
 
-def plot_mol_minima(dataframes, ref_method, out_file='minimaE.png', what_for='talk', selected=None):
+def plot_mol_minima(dataframes, method, out_file='minimaE.png', what_for='talk', selected=None):
     """
     Generate line plot of conformer energies of all methods (single molecule).
 
@@ -915,8 +916,8 @@ def plot_mol_minima(dataframes, ref_method, out_file='minimaE.png', what_for='ta
         xaxis_font = 10
         mark_size = 9
 
-    for mid in dataframes[ref_method].molecule_index.unique():    
-        ref_confs = dataframes[ref_method].loc[dataframes[ref_method].molecule_index==mid]
+    for mid in dataframes[method].molecule_index.unique():    
+        ref_confs = dataframes[method].loc[dataframes[method].molecule_index==mid]
         ref_nconfs = ref_confs.shape[0]
 
         # set figure-related labels

--- a/openff/benchmark/analysis/draw.py
+++ b/openff/benchmark/analysis/draw.py
@@ -525,8 +525,6 @@ def draw_density2d(
 
 
 def plot_compare_ffs(results_dir, output_directory):
-    global results
-    global method
     os.makedirs(output_directory, exist_ok=True)
     results = {}
     for path in results_dir:

--- a/openff/benchmark/analysis/draw.py
+++ b/openff/benchmark/analysis/draw.py
@@ -17,6 +17,7 @@ from scipy.interpolate import interpn
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import seaborn as sns
+import warnings
 
 def draw_scatter(
     x_data, y_data, method_label, x_label, y_label, out_file, what_for="talk"
@@ -452,8 +453,8 @@ def draw_density2d(
 
     # remove any nans from x_data, such as TFD score for urea-like mols
     nan_inds = x_data.isna()
-    x_data = x_data.dropna()
-    y_data = y_data[~nan_inds]
+    x_data = x_data.dropna().values
+    y_data = y_data[~nan_inds].values
 #    print('nan', x_data.isna().sum(), y_data.isna().sum())
 #    print('xd', x_data, x_data.max(), x_data.min())
 #    print('yd', y_data, y_data.max(), y_data.min())
@@ -491,7 +492,7 @@ def draw_density2d(
 
     # sort the points by density, so that the densest points are plotted last
     idx = z.argsort()
-    x, y, z = x_data.reindex(index=idx), y_data.reindex(index=idx), z[idx]
+    x, y, z = x_data[idx], y_data[idx], z[idx]
 
     # print(
     #     f"{title} ranges of data in density plot:\n\t\tmin\t\tmax"
@@ -524,6 +525,7 @@ def draw_density2d(
 
 
 def plot_compare_ffs(results_dir, ref_method, output_directory):
+    global results
     os.makedirs(output_directory, exist_ok=True)
     results = {}
     for path in results_dir:
@@ -537,6 +539,19 @@ def plot_compare_ffs(results_dir, ref_method, output_directory):
                     if (os.path.isfile(path) and path.split('.')[-1].lower() == 'csv'):
                         method = '.'.join(file.split('.')[:-1])
                         results[method] = pd.read_csv(path)
+
+    # apply the intersection method
+    for m, df in results.items():
+        results[m].set_index('name', inplace=True)
+
+    index_intersect = results[ref_method].index
+    for m in results:
+        index_intersect = index_intersect.intersection(results[m].index)
+    for m, df in results.items():
+        results[m] = df.loc[index_intersect]
+        if results[m].shape != df.shape:
+            warnings.warn(f"Not all conformers of method {m} considered, because these are not available in other methods.")
+
 
     plot_mol_minima(results, ref_method,  out_file=os.path.join(output_directory, 'minimaE.png'))
     # we do not want to plot the ref_method in the following plots
@@ -905,7 +920,7 @@ def plot_mol_minima(dataframes, ref_method, out_file='minimaE.png', what_for='ta
         ref_nconfs = ref_confs.shape[0]
 
         # set figure-related labels
-        mol_name = list(ref_confs['name'])[0]
+        mol_name = list(ref_confs.index)[0]
         plttitle = f"Relative Energies of {mol_name} Minima"
         ylabel = "ddE (kcal/mol)"
         figname = f"{out_file[:-4]}_{mol_name}{out_file[-4:]}"

--- a/openff/benchmark/cli.py
+++ b/openff/benchmark/cli.py
@@ -771,12 +771,11 @@ def match_minima(input_path, ref_method, output_directory):
 
 @report.command()
 @click.option('--input-path', multiple=True, required=True)
-@click.option('--ref-method', default='default', required=True)
 @click.option('--output-directory', default='5-plots-compare-forcefields', required=True)
-def plots(input_path, ref_method, output_directory):
+def plots(input_path, output_directory):
     from .analysis import draw
 
-    draw.plot_compare_ffs(input_path, ref_method, output_directory)
+    draw.plot_compare_ffs(input_path, output_directory)
 
 
 @cli.group()


### PR DESCRIPTION
The intersection method in draw.py allows the user to run the analysis on each different FF method as separate task, speeding up all the process. e.g.

```
for mm_path in `ls -d 4-compute-mm-filtered/*`; do 
   openff-benchmark report match-minima --input-path 4-compute-qm-filtered \
                                        --input-path $mm_path \
                                        --output-directory 5-match_minima &  done
```

In addition, the QM-to-QM comparison will be skipped.
Please note that now the plot command runs _without_ specifying the reference method, e.g.

```
openff-benchmark report plots --input-path 5-match_minima/
```
