### PR TITLE
Code refact and merge of old and new analyses

### DIFF
--- a/openff/benchmark/analysis/analysis.py
+++ b/openff/benchmark/analysis/analysis.py
@@ -8,8 +8,8 @@ assess them (e.g., having FF geometries) with respective to a reference SDF
 file (e.g., having QM geometries). Metrics include: RMSD of conformers, TFD
 (another geometric evaluation), and relative energy differences.
 
-By:      David F. Hahn
-Version: Dec 1 2020
+By:      David F. Hahn, Lorenzo D'Amore
+Version: Jul 22 2021
 
 """
 
@@ -24,39 +24,7 @@ from tqdm import tqdm
 
 from . import metrics, readwrite
 
-def get_ref_confs(dataframe):
-    ref_confs = {}
-    dataframe.loc[:,'ref_conf'] = False
-    for mid in tqdm(dataframe.molecule_index.unique(), desc='Finding reference molecules'):
-        confs = dataframe.loc[dataframe.molecule_index==mid]
-        if confs.shape[0] == 1:
-            ref_conf = confs.name[0]
-        else:
-            ref_conf = confs.final_energy.idxmin()
-        ref_confs[mid] = ref_conf
-        dataframe.loc[ref_conf, 'ref_conf'] = True
-    return ref_confs
-
-def ref_to_ref_confs(dataframe, ref_confs):
-    for mid in tqdm(dataframe.molecule_index.unique(), desc='Referencing energies'):
-        confs = dataframe.loc[dataframe.molecule_index==mid]
-        ref_conf = ref_confs[mid]
-        ref_energy = confs.loc[ref_conf, 'final_energy']
-        for i, row in confs.iterrows():
-            dataframe.loc[i, 'final_energy'] = row['final_energy'] - ref_energy
-            
-def calc_tfd(reference, result):
-    for i, row in tqdm(reference.iterrows(), desc='Calculating TFD'):
-        result.loc[i, 'tfd'] = metrics.calc_tfd(row['mol'].to_rdkit(), result.loc[i, 'mol'].to_rdkit())
-
-def calc_rmsd(reference, result):
-    for i, row in tqdm(reference.iterrows(), desc='Calculating RMSD'):
-        result.loc[i, 'rmsd'] = rdMolAlign.GetBestRMS(row['mol'].to_rdkit(), result.loc[i, 'mol'].to_rdkit())
-        
-def calc_dde(reference, result):
-    result.loc[:,'dde'] = result.final_energy - reference.final_energy
-
-def match_minima(input_path, ref_method, output_directory="./results"):
+def gather_df(input_path, ref_method):
     mols = {}
     dataframes = {}
     for path in tqdm(input_path, desc='Reading files'):
@@ -77,7 +45,10 @@ def match_minima(input_path, ref_method, output_directory="./results"):
         dataframes[method] = readwrite.mols_to_dataframe(mols[method])
 
     assert ref_method in mols, f"No molecules for reference method {ref_method} in input path(s)."
-    
+
+    return dataframes
+
+def intersect(dataframes, ref_method):
     index_intersect = dataframes[ref_method].index
     for m in tqdm(dataframes, desc='Checking input'):
         index_intersect = index_intersect.intersection(dataframes[m].index)
@@ -86,22 +57,64 @@ def match_minima(input_path, ref_method, output_directory="./results"):
         if dataframes[m].shape != df.shape:
             warnings.warn(f"Not all conformers of method {m} considered, because these are not available in other methods.")
 
+def get_confs_min(dataframe):
+    confs_min = {}
+    dataframe.loc[:,'conf_min'] = False
+    for mid in tqdm(dataframe.molecule_index.unique(), desc='Finding conformer minima'):
+        confs = dataframe.loc[dataframe.molecule_index==mid]
+        if confs.shape[0] == 1:
+            conf_min = confs.name[0]
+        else:
+            conf_min = confs.final_energy.idxmin()
+        confs_min[mid] = conf_min
+        dataframe.loc[conf_min, 'conf_min'] = True
+    return confs_min
+
+def calc_de(dataframe, confs_min):
+    for mid in tqdm(dataframe.molecule_index.unique(), desc='Calculating energy difference'):
+        confs = dataframe.loc[dataframe.molecule_index==mid]
+        conf_min = confs_min[mid]
+        ref_energy = confs.loc[conf_min, 'final_energy']
+        for i, row in confs.iterrows():
+            dataframe.loc[i, 'final_energy'] = row['final_energy'] - ref_energy
+            
+def calc_tfd(reference, result):
+    for i, row in tqdm(reference.iterrows(), desc='Calculating TFD'):
+        result.loc[i, 'tfd'] = metrics.calc_tfd(row['mol'].to_rdkit(), result.loc[i, 'mol'].to_rdkit())
+
+def calc_rmsd(reference, result):
+    for i, row in tqdm(reference.iterrows(), desc='Calculating RMSD'):
+        result.loc[i, 'rmsd'] = rdMolAlign.GetBestRMS(row['mol'].to_rdkit(), result.loc[i, 'mol'].to_rdkit())
+        
+def calc_dde(reference, result):
+    result.loc[:,'dde'] = result.final_energy - reference.final_energy
+
+def match_minima(input_path, ref_method, output_directory="./results"):
+    
+    # collects the input molecules and build a dataframe 
+    dataframes = gather_df(input_path, ref_method)
+ 
+    # takes only conformers which are present in all the methods
+    intersect(dataframes, ref_method)
+
     # get a dictionary with molecule index as key and the name of the reference as item
-    ref_confs = get_ref_confs(dataframes[ref_method])
+    confs_min = get_confs_min(dataframes[ref_method])
+
     # reference all final energies to the reference conformer's final energy (the reference conformers final energy will be 0 afterwards)
-    ref_to_ref_confs(dataframes[ref_method], ref_confs)
+    calc_de(dataframes[ref_method], confs_min)
     os.makedirs(output_directory, exist_ok=True)
+    
     # loop over methods
     for m in dataframes:
         # if the method is the reference method, we do not do the comparison
         # because it's just a comparison with itself
         if m == ref_method:
             continue
-        match = compare_conformers(dataframes[ref_method], dataframes[m], 1.0)
-        new_ref_confs = {molecule_id: 
+        match = get_ref_conf(dataframes[ref_method], dataframes[m])
+        ref_confs = {molecule_id: 
                          match[ match['name'] == ref_conformer ]['ff_mol_name'].values[0] 
-                         for molecule_id, ref_conformer in ref_confs.items() }
-        ref_to_ref_confs(dataframes[m], new_ref_confs)
+                         for molecule_id, ref_conformer in confs_min.items() }
+        calc_de(dataframes[m], ref_confs)
         for i, row in match.iterrows():
             match.loc[i, 'tfd'] = metrics.calc_tfd(
                 dataframes[ref_method].loc[row['name'], 'mol'].to_rdkit(), 
@@ -113,10 +126,151 @@ def match_minima(input_path, ref_method, output_directory="./results"):
                                 columns=['name', 'group_name', 'molecule_index', 'conformer_index', 'ff_mol_name', 'rmsd', 'tfd', 'dde']
         )
 
-def compare_conformers(reference, result, rmsd_cutoff):
+
+def lucas(input_path, ref_method, output_directory="./5-results-lucas"):
     """
-    For different methods, match the conformer minima to those of the reference
-    method. Ex. Conf G of reference method matches with conf R of method 2.
+    The command accepts the paths of the optimized molecules obtained from the optimization step
+    and creates one output csv file per method.
+    For each molecule, the code finds the MM reference conformer (ref_conf) with the lowest RMSD
+    value with respect to the QM global minimum (qm_min) and then reports the relative energy (dE) 
+    and RMDS between ref_conf and the MM global minimum (mm_min).
+
+    """
+
+    # collects the input molecules and build a dataframe
+    dataframes = gather_df(input_path, ref_method)
+
+    # takes only conformers which are present in all the methods
+    intersect(dataframes, ref_method)
+
+    # find QM min
+    qm_df = dataframes[ref_method]
+    qm_mins = get_confs_min(qm_df)
+
+    os.makedirs(output_directory, exist_ok=True)
+
+    # find the MM conformer closest to QM qm_min based on rmsd
+    # loop over methods
+
+    for m in dataframes:
+
+        # if the method is the reference method, we do not do the comparison
+        # because it's just a comparison with itself
+        if m == ref_method:
+            continue
+
+        mm_df = dataframes[m]
+
+        match = get_ref_conf(qm_df, mm_df)
+        ref_confs = {molecule_id:
+                                 match[ match['name'] == ref_conformer ]['ff_mol_name'].values[0]
+                                 for molecule_id, ref_conformer in qm_mins.items() }
+
+        # find MM min
+        mm_mins = get_confs_min(dataframes[m])
+
+        # calculate dE between ref_conf and mm_min
+        for i, row in mm_df.iterrows():
+            mm_min = mm_mins[row['molecule_index']]
+            ref_conf = ref_confs[row['molecule_index']]
+            if row['conf_min'] == True:
+                mm_df.loc[i, 'final_energy'] = mm_df.loc[ref_conf,'final_energy'] - mm_df.loc[mm_min,'final_energy']
+
+        # calculate RMSD between mm_min and ref_conf
+        for i, row in mm_df.iterrows():
+            mm_min = mm_mins[row['molecule_index']]
+            ref_conf = ref_confs[row['molecule_index']]
+            if row['conf_min'] == True:
+                mm_df.loc[i, 'rmsd'] = rdMolAlign.GetBestRMS(
+                                qm_df.loc[ref_conf, 'mol'].to_rdkit(), qm_df.loc[mm_min, 'mol'].to_rdkit())
+
+        # take only the mm_min = True of the dataframe
+        mm_results = mm_df.loc[mm_df.conf_min].copy()
+
+        # adds qm_min and ref_conf to the new dataframe
+        for i, row in mm_results.iterrows():
+            qm_min = qm_mins[row['molecule_index']]
+            ref_conf = ref_confs[row['molecule_index']]
+            mm_results.loc[i, 'qm_min'] = qm_min
+            mm_results.loc[i, 'ref_conf'] = ref_conf
+
+        mm_results = mm_results.rename(columns={'name':'mm_min', 'ref_conf':'mm_ref',
+                                                'rmsd':'rmsd (mm_ref/mm_min)', 'final_energy':'dE (mm_ref-mm_min)'})
+
+        mm_results = mm_results[['qm_min', 'mm_ref', 'mm_min', 'rmsd (mm_ref/mm_min)', 'dE (mm_ref-mm_min)']]
+
+        mm_results.to_csv(os.path.join(output_directory, f"lucas_{m}.csv"), index=False, float_format='%15.8e')
+
+
+def swope(input_path, ref_method, output_directory="./5-results-swope"):
+    """
+    The command accepts the paths of the optimized molecules obtained from the optimization step
+    and creates one output csv file per method.
+    For each molecule, the code reports (i) the relative energy (dE) between each MM conformer and the MM 
+    conformer which is the global minimum (mm_min); (ii) the RMSD between each MM conformer and the QM
+    conformer which is the global minimum (qm_min).
+
+    """
+
+    # collects the input molecules and build a dataframe
+    dataframes = gather_df(input_path, ref_method)
+
+    # takes only conformers which are present in all the methods
+    intersect(dataframes, ref_method)
+
+    # find QM min
+    qm_df = dataframes[ref_method]
+    qm_mins = get_confs_min(qm_df)
+
+    os.makedirs(output_directory, exist_ok=True)
+
+    # loop over methods
+    for m in dataframes:
+        # if the method is the reference method, we do not do the comparison
+        # because it's just a comparison with itself
+        if m == ref_method:
+            continue
+
+        # find MM min
+        mm_df = dataframes[m]
+        mm_mins = get_confs_min(dataframes[m])
+
+        # calculate dE between ech MM conformer and mm_min
+        for mid in tqdm(mm_df.molecule_index.unique(), desc='Calculating energy difference'):
+            confs = mm_df.loc[mm_df.molecule_index==mid]
+            mm_min = mm_mins[mid]
+            mm_min_energy = confs.loc[mm_min, 'final_energy']
+            for i, row in confs.iterrows():
+                mm_df.loc[i, 'final_energy'] = row['final_energy'] - mm_min_energy
+
+        # calculate RMSD
+        for i, row in tqdm(mm_df.iterrows(), desc='Calculating RMSD'):
+            qm_min = qm_mins[row['molecule_index']]
+            mm_df.loc[i, 'rmsd'] = rdMolAlign.GetBestRMS(
+                             row['mol'].to_rdkit(), qm_df.loc[qm_min, 'mol'].to_rdkit())
+
+        mm_results = mm_df.copy()
+
+        # adds qm_min and mm_min to the new dataframe
+        for i, row in mm_results.iterrows():
+            qm_min = qm_mins[row['molecule_index']]
+            mm_min = mm_mins[row['molecule_index']]
+            mm_results.loc[i, 'qm_min'] = qm_min
+            mm_results.loc[i, 'mm_min'] = mm_min
+
+        mm_results = mm_results.rename(columns={'name':'mm_conf', 'rmsd':'rmsd (mm_conf/qm_min)',
+                                                'final_energy':'dE (mm_conf-mm_min)'})
+        
+        mm_results = mm_results[['qm_min', 'mm_conf', 'mm_min', 'rmsd (mm_conf/qm_min)', 'dE (mm_conf-mm_min)']]
+
+        mm_results.to_csv(os.path.join(output_directory, f"swope_{m}.csv"), index=False, float_format='%15.8e')
+
+
+
+def get_ref_conf(reference, result):
+    """
+    For each MM method, get the conformers that are the closest (by RMSD) to the global 
+    minima conformers calculated with the reference (QM) method.
 
     Parameters
     ----------
@@ -124,8 +278,6 @@ def compare_conformers(reference, result, rmsd_cutoff):
         dictionary from input file, where key is method and value is dictionary
         first entry should be reference method
         in sub-dictionary, keys are 'sdfile' and 'sdtag'
-    rmsd_cutoff : float
-        cutoff above which two structures are considered diff conformers
 
     Returns
     -------
@@ -138,10 +290,10 @@ def compare_conformers(reference, result, rmsd_cutoff):
     
     conformer_match = reference.copy()
     for mid in tqdm(reference.molecule_index.unique(), desc='Matching conformers'):
-        ref_confs = reference.loc[reference.molecule_index==mid]
+        confs_min = reference.loc[reference.molecule_index==mid]
         query_confs = result.loc[result.molecule_index==mid]
-        rms_matrix = {i: {} for i, ref_row in ref_confs.iterrows()}
-        for i, ref_row in ref_confs.iterrows():
+        rms_matrix = {i: {} for i, ref_row in confs_min.iterrows()}
+        for i, ref_row in confs_min.iterrows():
             for j, query_row in query_confs.iterrows():
                 rmsd = rdMolAlign.GetBestRMS(ref_row['mol'].to_rdkit(), query_row['mol'].to_rdkit())
                 rms_matrix[i][j] = rmsd
@@ -151,7 +303,6 @@ def compare_conformers(reference, result, rmsd_cutoff):
             conformer_match.loc[ref, 'rmsd'] = rms_list[conf]
 
     return conformer_match
-
 
 
 def main(input_path, ref_method, output_directory="./results"):
@@ -172,44 +323,20 @@ def main(input_path, ref_method, output_directory="./results"):
         Directory path to deposit exported data. If not present, this 
         directory will be created. default: ./results/
     """
-    mols = {}
-    dataframes = {}
-    for path in tqdm(input_path, desc='Reading files'):
-        # read in molecules
-        m_mols = readwrite.read_sdfs(path)
+    # collects the input molecules and build a dataframe
+    dataframes = gather_df(input_path, ref_method)
 
-        # assert that all molecules of path are from the same method
-        for mol in m_mols:
-            # specify method of molecules
-            method = mol.properties['method']
-            if method in mols:
-                mols[method].append(mol)
-            else:
-                mols[method] = [ mol ]
-                
-    # convert molecules to dataframes
-    for method in mols:
-        dataframes[method] = readwrite.mols_to_dataframe(mols[method])
+    # takes only conformers which are present in all the methods
+    intersect(dataframes, ref_method)
 
-    assert ref_method in mols, f"Input path for reference method {ref_method} not specified."
-
-    index_intersect = dataframes[ref_method].index
-    for m in tqdm(dataframes, desc='Checking input'):
-        index_intersect = index_intersect.intersection(dataframes[m].index)
-    for m, df in tqdm(dataframes.items(), desc='Checking input'):
-        dataframes[m] = df.loc[index_intersect]
-        if dataframes[m].shape != df.shape:
-            warnings.warn(f"Not all conformers of method {m} considered, because these are not available in other methods.")
-
-
-    ref_confs = get_ref_confs(dataframes[ref_method])
-    ref_to_ref_confs(dataframes[ref_method], ref_confs)
+    confs_min = get_confs_min(dataframes[ref_method])
+    calc_de(dataframes[ref_method], confs_min)
 
     os.makedirs(output_directory, exist_ok=True)
     for m in tqdm(dataframes, desc='Processing data'):
         if m == ref_method:
             continue
-        ref_to_ref_confs(dataframes[m], ref_confs)
+        calc_de(dataframes[m], confs_min)
         calc_rmsd(dataframes[ref_method], dataframes[m])
         calc_tfd(dataframes[ref_method], dataframes[m])
         calc_dde(dataframes[ref_method], dataframes[m])

--- a/openff/benchmark/analysis/analysis.py
+++ b/openff/benchmark/analysis/analysis.py
@@ -140,12 +140,23 @@ def match_minima(input_path, ref_method, output_directory="./results"):
 
 
 def lucas(input_path, ref_method, output_directory="./5-results-lucas"):
-    """
+    """Execute comparison analysis proposed by Xavier Lucas.
+
     The command accepts the paths of the optimized molecules obtained from the optimization step
     and creates one output csv file per method.
+
     For each molecule, the code finds the MM reference conformer (ref_conf) with the lowest RMSD
     value with respect to the QM global minimum (qm_min) and then reports the relative energy (dE) 
     and RMDS between ref_conf and the MM global minimum (mm_min).
+
+    Parameters
+    ----------
+    input_path : Iterable[Path-like]
+        Input paths to gather input SDFs of molecule conformers to compare.
+    ref_methd : str
+        The value of the SDF property `method` to use as the reference method.
+    output_directory : Path-like
+        The directory in which to output results.
 
     """
 
@@ -215,12 +226,23 @@ def lucas(input_path, ref_method, output_directory="./5-results-lucas"):
 
 
 def swope(input_path, ref_method, output_directory="./5-results-swope"):
-    """
+    """Execute comparison analysis proposed by William Swope.
+
     The command accepts the paths of the optimized molecules obtained from the optimization step
     and creates one output csv file per method.
+
     For each molecule, the code reports (i) the relative energy (dE) between each MM conformer and the MM 
     conformer which is the global minimum (mm_min); (ii) the RMSD between each MM conformer and the QM
     conformer which is the global minimum (qm_min).
+
+    Parameters
+    ----------
+    input_path : Iterable[Path-like]
+        Input paths to gather input SDFs of molecule conformers to compare.
+    ref_methd : str
+        The value of the SDF property `method` to use as the reference method.
+    output_directory : Path-like
+        The directory in which to output results.
 
     """
 

--- a/openff/benchmark/analysis/draw.py
+++ b/openff/benchmark/analysis/draw.py
@@ -39,10 +39,18 @@ def get_results(results_dir):
 
 def res_inters(results, method, idx):
     """
-    Takes only conformer which are present in all methods
+    Takes only conformer which are present in all methods.
+
+    Modifies `results` dictionary Dataframes in-place.
 
     Parameters
-    ---------
+    ----------
+    results : Dict[str, pd.DataFrame]
+        Dict of Dataframes with method as keys, results as values.
+        This function modifies the Dataframes in-place.
+    method : str
+        Key in results used as the first method for intersection.
+        Can ultimately be any key in the dictionary due to the nature of the intersection.
     idx : string
         idx is the column of the results df containing the molecule index:
         'name' for compare-ff, match-minima
@@ -280,7 +288,6 @@ def draw_ridgeplot(
 
     temp = []
     for method, result in dataframes.items():
-#        import pdb; pdb.set_trace()
         result = result.rename(columns={key: x_label})
         result["method"] = method
         temp.append(result)
@@ -558,7 +565,7 @@ def draw_density2d(
 def plot_compare_ffs(results_dir, output_directory):
     os.makedirs(output_directory, exist_ok=True)
 
-    results,method = get_results(results_dir)
+    results, method = get_results(results_dir)
 
     res_inters(results, method, 'name')
 
@@ -688,7 +695,8 @@ def plot_compare_ffs(results_dir, output_directory):
         bw="hist",
         same_subplot=True,
         sym_log=False,
-        hist_range=(-15,15)
+        hist_range=(-15,15),
+        stat="probability"
     )
     draw_ridgeplot(
         results,
@@ -700,7 +708,8 @@ def plot_compare_ffs(results_dir, output_directory):
         bw="hist",
         same_subplot=True,
         sym_log=False,
-        hist_range=(0, 3)
+        hist_range=(0, 3),
+        stat="probability"
     )
     draw_ridgeplot(
         results,
@@ -712,14 +721,15 @@ def plot_compare_ffs(results_dir, output_directory):
         bw="hist",
         same_subplot=True,
         sym_log=False,
-        hist_range=(0, 0.5)
+        hist_range=(0, 0.5),
+        stat="probability"
     )
     
 
 def plot_lucas(results_dir, output_directory):
     os.makedirs(output_directory, exist_ok=True)
 
-    results,method = get_results(results_dir)
+    results, method = get_results(results_dir)
 
     res_inters(results, method, 'mm_ref')
 
@@ -793,7 +803,8 @@ def plot_lucas(results_dir, output_directory):
         bw="hist",
         same_subplot=True,
         sym_log=False,
-        hist_range=(-1.67,15)
+        hist_range=(-1.67,15),
+        stat="probability"
     )
 
     draw_ridgeplot(
@@ -806,7 +817,8 @@ def plot_lucas(results_dir, output_directory):
         bw="hist",
         same_subplot=True,
         sym_log=False,
-        hist_range=(0, 3)
+        hist_range=(0, 3),
+        stat="probability"
     )
 
 
@@ -1096,23 +1108,28 @@ def plot_mol_rmses(mol_name, rmses, xticklabels, eff_nconfs, ref_nconfs, what_fo
     plt.close(plt.gcf())
 
 
-def plot_mol_minima(dataframes, y_label, y_data, method, out_file='minimaE.png', what_for='talk', selected=None):
+def plot_mol_minima(dataframes, y_label, y_data, method, out_file='minimaE.png', what_for='talk'):
     """
     Generate line plot of conformer energies of all methods (single molecule).
 
     Parameters
     ----------
-    mol_name : string
-        title of the mol being plotted
-    minimaE : list of lists
-        minimaE[i][j] represents ith method and jth conformer energy
-    legend : list
-        list of strings with all method names in same order as minimaE
+    dataframes : Dict[str, pd.DataFrame]
+        Dict of Dataframes with method as keys, results as values.
+        This function modifies the Dataframes in-place.
+    y_label : str
+        y-axis label to use on the resulting plot.
+    y_data : str
+        Column name in each Dataframe corresponding to y-axis data.
+    method : str
+        Key in `dataframes` used as the reference method for figure generation.
+        Can ultimately be any key in the dictionary; does not matter which.
+    out_file : Path-like
+        Name of output file for rendered figure.
+        Extension indicates type of image format used.
     what_for : string
         dictates figure size, text size of axis labels, legend, etc.
         "paper" or "talk"
-    selected : list
-        list of indices for methods to be plotted; e.g., [0], [0, 4]
 
     """
     if what_for == 'paper':

--- a/openff/benchmark/cli.py
+++ b/openff/benchmark/cli.py
@@ -750,19 +750,53 @@ def report():
 
 
 @report.command()
-@click.option('--input-path', multiple=True, required=True)
-@click.option('--ref-method', default='b3lyp-d3bj', required=True)
-@click.option('--output-directory', default='5-compare_forcefields', required=True)
+@click.option(
+    '--input-path',
+    multiple=True,
+    required=True,
+    help="Input directory of the QM optimization and MM optimization"
+)
+@click.option(
+    '--ref-method',
+    default='b3lyp-d3bj',
+    required=True,
+    help="Reference method, typically the QM method"
+)
+@click.option(
+    '--output-directory',
+    default='5-compare-forcefields',
+    required=True,
+    help="Output directory where the analysis results will be stored"
+)
 def compare_forcefields(input_path, ref_method, output_directory):
+    """
+    Compute the relative energy difference (ddE) between the FF and QM energy
+    for the i-th conformer.
+    """
     from .analysis import analysis
 
     analysis.main(input_path, ref_method, output_directory)
 
 
 @report.command()
-@click.option('--input-path', multiple=True, required=True)
-@click.option('--ref-method', default='b3lyp-d3bj', required=True)
-@click.option('--output-directory', default='5-match_minima', required=True)
+@click.option(
+    '--input-path',
+    multiple=True,
+    required=True,
+    help="Input directory of the QM optimization and MM optimization"
+)
+@click.option(
+    '--ref-method',
+    default='b3lyp-d3bj',
+    required=True,
+    help="Reference method, typically the QM method"
+)
+@click.option(
+    '--output-directory',
+    default='5-match-minima',
+    required=True,
+    help="Output directory where the analysis results will be stored"
+)
 def match_minima(input_path, ref_method, output_directory):
     from .analysis import analysis
 
@@ -770,12 +804,136 @@ def match_minima(input_path, ref_method, output_directory):
 
 
 @report.command()
-@click.option('--input-path', multiple=True, required=True)
-@click.option('--output-directory', default='5-plots-compare-forcefields', required=True)
+@click.option(
+    '--input-path',
+    multiple=True,
+    required=True,
+    help="Input directory containing the analysis results to be plotted"
+)
+@click.option(
+    '--output-directory',
+    default='5-plots-compare-forcefields',
+    required=True,
+    help="Output directory where the plots will be stored"
+)
 def plots(input_path, output_directory):
+    """ Generate plots from the compare-forcefields or match-minima analysis """
     from .analysis import draw
 
     draw.plot_compare_ffs(input_path, output_directory)
+
+
+@report.command()
+@click.option(
+    '--input-path',
+    multiple=True,
+    required=True,
+    help="Input directory of the QM optimization and MM optimization"
+)
+@click.option(
+    '--ref-method',
+    default='b3lyp-d3bj',
+    required=True,
+    help="Reference method, typically the QM method"
+)
+@click.option(
+    '--output-directory',
+    default='5-results-lucas',
+    required=True,
+    help="Output directory where the analysis results will be stored"
+)
+def lucas(input_path, ref_method, output_directory):
+    """
+    Execute the analysis proposed by Lucas.
+    For each molecule, the code finds the MM reference conformer (mm_ref) with the lowest RMSD
+    value with respect to the QM global minimum (qm_min) and then reports the relative energy (dE)
+    and RMDS between ref_conf and the MM global minimum (mm_min).
+    """
+    from .analysis import analysis
+    analysis.lucas(input_path, ref_method, output_directory)
+
+
+@report.command()
+@click.option(
+    '--input-path',
+    multiple=True,
+    required=True,
+    help="Input directory of the QM optimization and MM optimization"
+)
+@click.option(
+    '--ref-method',
+    default='b3lyp-d3bj',
+    required=True,
+    help="Reference method, typically the QM method"
+)
+@click.option(
+    '--output-directory',
+    default='5-results-swope',
+    required=True,
+    help="Output directory where the analysis results will be stored"
+)
+def swope(input_path, ref_method, output_directory):
+    """
+    Execute the analysis proposed by Swope
+    For each molecule, the code reports (i) the relative energy (dE) between each MM conformer (mm_conf)
+    and the MM conformer which is the global minimum (mm_min); (ii) the RMSD between each MM conformer 
+    and the QM conformer which is the global minimum (qm_min).
+
+    """
+    from .analysis import analysis
+    analysis.swope(input_path, ref_method, output_directory)
+
+
+@report.command()
+@click.option(
+    '--input-path',
+    multiple=True,
+    required=True,
+    help="Input directory containing the analysis results to be plotted"
+)
+@click.option(
+    '--output-directory',
+    default='6-plots-xavier',
+    required=True,
+    help="Output directory where the plots will be stored"
+)
+def plots_lucas(input_path, output_directory):
+    """ Generate plots from the analysis proposed by Lucas """
+
+    from .analysis import draw
+    draw.plot_lucas(input_path, output_directory)
+
+
+@report.command()
+@click.option(
+    '--input-path',
+    multiple=True,
+    required=True,
+    help="Input directory containing the analysis results to be plotted"
+)
+@click.option(
+    '--de-cutoff',
+    default='default',
+    required=True,
+    help="dE cutoff value to generate an rmsd ridge plot taking into account only conformers of relative energy within the given threshold"
+)
+@click.option(
+    '--rmsd-cutoff',
+    default='default',
+    required=True,
+    help="Rmsd cutoff value to generate a dE ridge plot taking into account only conformers with rmsd within the given threshold"
+)
+@click.option(
+    '--output-directory',
+    default='6-plots-bill',
+    required=True,
+    help="Output directory where the plots will be stored"
+)
+def plots_swope(input_path, de_cutoff, rmsd_cutoff, output_directory):
+    """ Generate plots from the analysis proposed by Swope """
+
+    from .analysis import draw
+    draw.plot_swope(input_path, de_cutoff, rmsd_cutoff, output_directory)
 
 
 @cli.group()

--- a/openff/benchmark/cli.py
+++ b/openff/benchmark/cli.py
@@ -843,11 +843,12 @@ def plots(input_path, output_directory):
     help="Output directory where the analysis results will be stored"
 )
 def lucas(input_path, ref_method, output_directory):
-    """
-    Execute the analysis proposed by Lucas.
-    For each molecule, the code finds the MM reference conformer (mm_ref) with the lowest RMSD
-    value with respect to the QM global minimum (qm_min) and then reports the relative energy (dE)
-    and RMDS between ref_conf and the MM global minimum (mm_min).
+    """Execute the analysis proposed by Lucas.
+
+    For each molecule, find the MM reference conformer (mm_ref) with the lowest RMSD
+    value with respect to the QM global minimum (qm_min); report the relative energy (dE)
+    and RMSD between ref_conf and the MM global minimum (mm_min).
+
     """
     from .analysis import analysis
     analysis.lucas(input_path, ref_method, output_directory)
@@ -873,11 +874,13 @@ def lucas(input_path, ref_method, output_directory):
     help="Output directory where the analysis results will be stored"
 )
 def swope(input_path, ref_method, output_directory):
-    """
-    Execute the analysis proposed by Swope
-    For each molecule, the code reports (i) the relative energy (dE) between each MM conformer (mm_conf)
-    and the MM conformer which is the global minimum (mm_min); (ii) the RMSD between each MM conformer 
-    and the QM conformer which is the global minimum (qm_min).
+    """Execute the analysis proposed by Swope.
+
+    For each molecule, report:
+    (i)  the relative energy (dE) between each MM conformer (mm_conf)
+         and the global minimum MM conformer (mm_min); 
+    (ii) the RMSD between each MM conformer 
+         and the global minimum QM conformer (qm_min).
 
     """
     from .analysis import analysis
@@ -898,7 +901,7 @@ def swope(input_path, ref_method, output_directory):
     help="Output directory where the plots will be stored"
 )
 def plots_lucas(input_path, output_directory):
-    """ Generate plots from the analysis proposed by Lucas """
+    """ Generate plots from the analysis proposed by Lucas. """
 
     from .analysis import draw
     draw.plot_lucas(input_path, output_directory)
@@ -921,7 +924,7 @@ def plots_lucas(input_path, output_directory):
     '--rmsd-cutoff',
     default='default',
     required=True,
-    help="Rmsd cutoff value to generate a dE ridge plot taking into account only conformers with rmsd within the given threshold"
+    help="RMSD cutoff value to generate a dE ridge plot taking into account only conformers with RMSD within the given threshold"
 )
 @click.option(
     '--output-directory',
@@ -930,7 +933,7 @@ def plots_lucas(input_path, output_directory):
     help="Output directory where the plots will be stored"
 )
 def plots_swope(input_path, de_cutoff, rmsd_cutoff, output_directory):
-    """ Generate plots from the analysis proposed by Swope """
+    """ Generate plots from the analysis proposed by Swope. """
 
     from .analysis import draw
     draw.plot_swope(input_path, de_cutoff, rmsd_cutoff, output_directory)


### PR DESCRIPTION
## Description
This PR introduces two additional benchmark analysis proposed by B. Swope and X. Lucas.

## Installation of `analysis` command group in a new conda environment

First, follow the installation procedures for the `openff-benchmark-optimization` environment described in [Deployment Procedure document](https://openforcefield.atlassian.net/wiki/spaces/PS/pages/873922575/Deployment+Procedure#Installation)

Once this is done, you can clone the environment into a new conda environment:

```
conda create -n openff-analysis --clone openff-benchmark-optimization
conda activate openff-analysis
```

Install the `analysis` branch from github:

```
git clone https://github.com/openforcefield/openff-benchmark
cd openff-benchmark
git checkout --track origin/analysis
pip install -e .
```

## General comments
The two new analysis are typically executed at *point (5)* of the [Optimization Benchmark Protocol](https://openforcefield.atlassian.net/wiki/spaces/PS/pages/971898891/Optimization+Benchmarking+Protocol+-+Season+1)

With `openff-benchmark report swope` the analysis proposed by B. Swope is executed. The command accepts the paths of the optimized molecules obtained from the optimization step. Additionally, the reference method (b3lyp-d3bj by default) and an output directory can be specified.

  `openff-benchmark report swope --input-path 4-compute-qm-filtered --input-path 4-compute-mm-filtered --ref-method b3lyp-d3bj  --output-directory 5-results-swope`

The command creates one output csv file per method, which are named `swope_<method>.csv`, i.e. `swope_openff-1.0.0.csv`

The analysis proposed by B. Swope operates as follows:

- For each molecule MOL-00001-XX.sdf

  - Report the relative energy (**dE**) of each MM optimized conformer (**MM_conf**) with respect to the MM optimized conformer which is the global minimum (**MM_min**)

  - **dE = E<sub>MM_conf</sub> - E<sub>MM_min</sub>**

  - Report the RMSD between each **MM_conf** and the QM optimized conformer which is the global minimum (**QM_min**)

  - **RMSD (MM_conf | QM_min)**

With `openff-benchmark report lucas` the analysis proposed by X. Lucas is executed. The command accepts the paths of the optimized molecules obtained from the optimization step. Additionally, the reference method (b3lyp-d3bj by default) and an output directory can be specified.

`openff-benchmark report lucas --input-path 4-compute-qm-filtered --input-path 4-compute-mm-filtered --ref-method b3lyp-d3bj --output-directory 5-results-lucas`

The command creates one output csv file per method, which are named `lucas_<method>.csv`, i.e. `lucas_openff-1.0.0.csv`

The analysis proposed by X. Lucas operates as follows:

- For each molecule MOL-00001-XX.sdf

  - Find the MM reference conformer (**MM_ref**) with the lowest RMSD with respect to **QM_min**

  - Report the relative energy (**dE**) and RMSD between **MM_ref** and **MM_min**

  - **dE = E<sub>MM_ref</sub> - E<sub>MM_min</sub>**

  - **RMSD (MM_ref | MM_min)**

The final `openff-benchmark report plots-swope` and `openff-benchmark report plots-lucas` commands take the directories containing the csv files as an input (output of `5-results-swope` or `5-results-lucas`).

For `5-results-swope` an `rmsd-cutoff` and `de-cutoff` should be set. 

`openff-benchmark report plots-swope --input-path 5-results-swope/ --de-cutoff 1.5 --rmsd-cutoff 1.0 `

The algorithm will generate a ridge plot of all the conformers within the rmsd-cutoff for a range of dE values, and another ridge plot of all the conformers within the de-cutoff for a range of rsmd values.

For `5-results-lucas`

`openff-benchmark report plots-lucas --input-path 5-results-lucas/`

The algorithm will generate similar plots as for `compare-forcefields` and `match_minima`

### Please note
Likewise `openff-benchmark report match-minima`, also `openff-benchmark report lucas` matches the conformers by rmsd and this step is quite time consuming. However, the intersection method added in this PR now allows the user to run the analysis on each different FF method as separate task, speeding up all the process. e.g.

```
for mm_path in `ls -d 4-compute-mm-filtered/*`; do 
   openff-benchmark report match-minima --input-path 4-compute-qm-filtered \
                                        --input-path $mm_path \
                                        --output-directory 5-results-lucas &  done
```

In addition, the QM-to-QM comparison will be skipped.
Please note that now the plot commands runs _without_ specifying the reference method, e.g.

```
openff-benchmark report plots-lucas --input-path 5-results-lucas/
```

## Todos

  - [x] Fix an error that prevent the drawing of density plots when using the intersection of methods at the plotting stage.
  - [x] Introduced the intersection of methods at the plotting stage. 
  - [ ] Increase the size of y_ticks_labels to the same as x_ticks_labels.

## Questions
- [ ] Question1

## Status
- [ x] Ready to go